### PR TITLE
Align prompts with gated lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,112 @@ This pack extends the default Codex CLI prompts with vibe-coding playbooks inspi
 
 ## Core slash commands
 
-| Command | File | What it does |
+Commands are grouped by development phase. Stage headings link back to
+[WORKFLOW.md](WORKFLOW.md) for owners, gates, and evidence expectations.
+
+### [P0 Preflight Docs](WORKFLOW.md#p0-preflight-docs-blocking) — DocFetchReport must be **OK**
+
+| Command | What it does |
+| --- | --- |
+| /instruction-file | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` so DocFetchReport captures current guardrails. |
+
+### [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope) — pass the [Scope Gate](WORKFLOW.md#scope-gate)
+
+| Command | What it does |
+| --- | --- |
+| /planning-process | Draft, refine, and execute a feature plan with strict scope control. |
+| /scope-control | Enforce explicit scope boundaries plus “won’t do” and “ideas for later” lists. |
+| /stack-evaluation | Evaluate language/framework choices relative to AI familiarity and roadmap goals. |
+
+### [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts) — clear Test Gate lite
+
+| Command | What it does |
+| --- | --- |
+| /scaffold-fullstack | Create a minimal full-stack workspace with CI seeds. |
+| /api-contract | Author an initial OpenAPI/GraphQL contract from requirements. |
+| /openapi-generate | Generate server stubs or typed clients from an OpenAPI spec. |
+| /modular-architecture | Enforce module boundaries; revisit during P4 for UI seams. |
+| /reference-implementation | Mimic the style and API of a known working example. |
+| /api-docs-local | Fetch API docs and store locally for deterministic reference. |
+
+### [P3 Data & Auth](WORKFLOW.md#p3-data--auth) — migrations must dry-run cleanly
+
+| Command | What it does |
+| --- | --- |
+| /db-bootstrap | Pick a database, initialize migrations, and seed scripts. |
+| /migration-plan | Produce safe up/down migration steps with rollback notes. |
+| /auth-scaffold | Scaffold auth flows, threat model, and secure session storage. |
+
+### [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) — queue accessibility checks
+
+| Command | What it does |
+| --- | --- |
+| /design-assets | Generate favicons and lightweight visual assets from your product brand. |
+| /ui-screenshots | Analyze screenshots for UI bugs or inspiration and propose actionable fixes. |
+
+### [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests) — meet the [Test Gate](WORKFLOW.md#test-gate)
+
+| Command | What it does |
+| --- | --- |
+| /e2e-runner-setup | Configure Playwright/Cypress with fixtures and CI jobs. |
+| /integration-test | Generate end-to-end tests that simulate real user flows. |
+| /coverage-guide | Suggest a plan to raise coverage based on uncovered areas. |
+| /regression-guard | Detect unrelated changes and add tests to prevent regressions. |
+
+### [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env) — satisfy the [Review Gate](WORKFLOW.md#review-gate)
+
+| Command | What it does |
+| --- | --- |
+| /version-control-guide | Enforce clean incremental commits and clean-room re-implementation before merge. |
+| /devops-automation | Configure servers, DNS, SSL, and CI/CD with pragmatic defaults. |
+| /env-setup | Create `.env.example`, runtime validation, and per-environment overrides. |
+| /secrets-manager-setup | Provision a secret store and map application variables. |
+| /iac-bootstrap | Create minimal IaC stacks with plan/apply pipelines. |
+
+### [P7 Release & Ops](WORKFLOW.md#p7-release--ops) — clear the [Release Gate](WORKFLOW.md#release-gate)
+
+| Command | What it does |
+| --- | --- |
+| /owners | Suggest owners and reviewers for a path using CODEOWNERS and history. |
+| /review | Review code matching a pattern and provide actionable feedback. |
+| /review-branch | Provide a high-level review of the branch compared to `origin/main`. |
+| /pr-desc | Draft a PR description from the branch diff. |
+| /release-notes | Convert recent commits into human-readable release notes. |
+| /version-proposal | Propose the next semantic version based on commit history. |
+| /monitoring-setup | Bootstrap logs, metrics, and traces with dashboards per domain. |
+| /slo-setup | Define SLOs, burn alerts, and supporting runbooks. |
+| /logging-strategy | Add or remove diagnostic logging with structured levels and privacy considerations. |
+
+### [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening) — resolve Sev-1 issues
+
+| Command | What it does |
+| --- | --- |
+| /error-analysis | Analyze error logs and enumerate likely root causes with fixes. |
+| /fix | Propose a minimal, correct fix with patch hunks. |
+| /refactor-suggestions | Propose repo-wide refactoring opportunities once tests exist. |
+| /file-modularity | Enforce smaller files and propose safe splits for giant files. |
+| /dead-code-scan | Flag likely dead files and exports using static signals. |
+| /cleanup-branches | Recommend local branches that are merged or stale and safe to delete. |
+| /feature-flags | Integrate a flag provider, wire SDK, and enforce guardrails. |
+
+### [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting) — document uplift before switching defaults
+
+| Command | What it does |
+| --- | --- |
+| /model-strengths | Route work by model strengths for faster delegation. |
+| /model-evaluation | Try a new model and compare outputs against a baseline. |
+| /compare-outputs | Run multiple models or tools on the same prompt and summarize the best output. |
+| /switch-model | Decide when to try a different AI backend and how to compare. |
+
+### [Reset Playbook](WORKFLOW.md#reset-playbook) and other cross-cutting helpers
+
+| Command | Stage tie-in | What it does |
 | --- | --- | --- |
-| /api-docs-local | api-docs-local.md | Fetch API docs and store locally for offline, deterministic reference. |
-| /compare-outputs | compare-outputs.md | Run multiple models or tools on the same prompt and summarize the best output. |
-| /content-generation | content-generation.md | Draft docs, blog posts, or marketing copy aligned with the codebase. |
-| /design-assets | design-assets.md | Generate favicons and lightweight visual assets from your product brand. |
-| /devops-automation | devops-automation.md | Configure servers, DNS, SSL, and CI/CD with pragmatic defaults. |
-| /error-analysis | error-analysis.md | Analyze error logs and enumerate likely root causes with fixes. |
-| /explain-code | explain-code.md | Provide line-by-line explanations for a given file or diff. |
-| /file-modularity | file-modularity.md | Enforce smaller files and propose safe splits for giant files. |
-| /instruction-file | instruction-file.md | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` with project-specific guidance. |
-| /integration-test | integration-test.md | Generate end-to-end tests that simulate real user flows. |
-| /logging-strategy | logging-strategy.md | Add or remove diagnostic logging with structured levels and privacy considerations. |
-| /model-evaluation | model-evaluation.md | Try a new model and compare outputs against a baseline. |
-| /model-strengths | model-strengths.md | Route work by model strengths for faster delegation. |
-| /modular-architecture | modular-architecture.md | Enforce module boundaries and external interfaces. |
-| /planning-process | planning-process.md | Draft, refine, and execute a feature plan with strict scope control. |
-| /prototype-feature | prototype-feature.md | Spin up a standalone prototype in a clean repo before merging into main. |
-| /refactor-suggestions | refactor-suggestions.md | Propose repo-wide refactoring opportunities once tests exist. |
-| /reference-implementation | reference-implementation.md | Mimic the style and API of a known working example. |
-| /regression-guard | regression-guard.md | Detect unrelated changes and add tests to prevent regressions. |
-| /reset-strategy | reset-strategy.md | Decide when to hard reset and start clean to avoid layered bad diffs. |
-| /scope-control | scope-control.md | Enforce explicit scope boundaries plus “won’t do” and “ideas for later” lists. |
-| /stack-evaluation | stack-evaluation.md | Evaluate language/framework choices relative to AI familiarity and roadmap goals. |
-| /switch-model | switch-model.md | Decide when to try a different AI backend and how to compare. |
-| /ui-screenshots | ui-screenshots.md | Analyze screenshots for UI bugs or inspiration and propose actionable fixes. |
-| /version-control-guide | version-control-guide.md | Enforce clean incremental commits and clean-room re-implementation before merge. |
-| /voice-input | voice-input.md | Convert speech to structured prompts for Codex. |
+| /reset-strategy | Reset path | Decide when to hard reset and start clean to avoid layered bad diffs. |
+| /prototype-feature | P1–P2 sandbox | Spin up a standalone prototype before merging into main. |
+| /content-generation | Support | Draft docs, blog posts, or marketing copy aligned with the codebase. |
+| /explain-code | Support | Provide line-by-line explanations for a given file or diff. |
+| /voice-input | Support | Convert speech to structured prompts for Codex. |
 
 ## Gemini→Codex Mapper templates (`/gemini-map`)
 
@@ -106,54 +184,111 @@ Each template below is invoked through `/gemini-map`. Supply any arguments reque
 
 ```mermaid
 flowchart TD
-  A["Preflight Docs (§A) AGENTS"] -->|DocFetchReport OK| B[/planning-process/]
-  B --> C[/scope-control/]
-  C --> D[/stack-evaluation/]
-  D --> E[/scaffold-fullstack/]
-  E --> F[/api-contract/]
-  F --> G[/openapi-generate/]
-  G --> H[/modular-architecture/]
-  H --> I[/db-bootstrap/]
-  I --> J[/migration-plan/]
-  J --> K[/auth-scaffold/]
-  K --> L[/e2e-runner-setup/]
-  L --> M[/integration-test/]
-  M --> N[/coverage-guide/]
-  N --> O[/regression-guard/]
-  O --> P[/version-control-guide/]
-  P --> Q[/devops-automation/]
-  Q --> R[/env-setup/]
-  R --> S[/secrets-manager-setup/]
-  S --> T[/iac-bootstrap/]
-  T --> U[/owners/]
-  U --> V[/review/]
-  V --> W[/review-branch/]
-  W --> X[/pr-desc/]
-  X --> Y{Gates}
-  Y -->|Scope Gate pass| Z1[proceed]
-  Y -->|Test Gate pass| Z2[proceed]
-  Y -->|Review Gate pass| Z3[proceed]
-  Z3 --> AA[/release-notes/]
-  AA --> AB[/version-proposal/]
-  AB --> AC{Release Gate}
-  AC -->|pass| AD[Deploy Staging]
-  AD --> AE[Canary + Health]
-  AE -->|ok| AF[Deploy Prod]
-  AE -->|fail| AR[Rollback]
-  AF --> AG[/monitoring-setup/]
-  AG --> AH[/slo-setup/]
-  AH --> AI[/logging-strategy/]
-  AI --> AJ[/error-analysis/]
-  AJ --> AK[/fix/]
-  AK --> AL[/refactor-suggestions/]
-  AL --> AM[/file-modularity/]
-  AM --> AN[/dead-code-scan/]
-  AN --> AO[/cleanup-branches/]
-  AF --> AP[/feature-flags/]
-  AF --> AQ[/model-strengths/]
-  AQ --> AR2[/model-evaluation/]
-  AR2 --> AS[/compare-outputs/]
-  AS --> AT[/switch-model/]
+  subgraph P0["P0 Preflight Docs"]
+    preflight["Preflight Docs (§A) AGENTS"]
+  end
+
+  subgraph P1["P1 Plan & Scope"]
+    plan[/planning-process/]
+    scope[/scope-control/]
+    stack[/stack-evaluation/]
+  end
+
+  subgraph P2["P2 App Scaffold & Contracts"]
+    scaffold[/scaffold-fullstack/]
+    api_contract[/api-contract/]
+    openapi[/openapi-generate/]
+    modular[/modular-architecture/]
+  end
+
+  subgraph P3["P3 Data & Auth"]
+    db[/db-bootstrap/]
+    migrate[/migration-plan/]
+    auth[/auth-scaffold/]
+  end
+
+  subgraph P4["P4 Frontend UX"]
+    assets[/design-assets/]
+    screenshots[/ui-screenshots/]
+  end
+
+  subgraph P5["P5 Quality Gates & Tests"]
+    e2e[/e2e-runner-setup/]
+    integration[/integration-test/]
+    coverage[/coverage-guide/]
+    regression[/regression-guard/]
+  end
+
+  subgraph P6["P6 CI/CD & Env"]
+    vcs[/version-control-guide/]
+    devops[/devops-automation/]
+    env[/env-setup/]
+    secrets[/secrets-manager-setup/]
+    iac[/iac-bootstrap/]
+  end
+
+  subgraph P7["P7 Release & Ops"]
+    owners[/owners/]
+    review[/review/]
+    review_branch[/review-branch/]
+    pr_desc[/pr-desc/]
+    release_notes[/release-notes/]
+    version[/version-proposal/]
+    monitoring[/monitoring-setup/]
+    slo[/slo-setup/]
+    logging[/logging-strategy/]
+  end
+
+  subgraph Deploy["Deployment Flow"]
+    deploy_staging[Deploy Staging]
+    canary[Canary + Health]
+    deploy_prod[Deploy Prod]
+    rollback[Rollback]
+  end
+
+  subgraph P8["P8 Post-release Hardening"]
+    error[/error-analysis/]
+    fix[/fix/]
+    refactor[/refactor-suggestions/]
+    modularity[/file-modularity/]
+    deadcode[/dead-code-scan/]
+    cleanup[/cleanup-branches/]
+    flags[/feature-flags/]
+  end
+
+  subgraph P9["P9 Model Tactics"]
+    strengths[/model-strengths/]
+    evaluation[/model-evaluation/]
+    compare[/compare-outputs/]
+    switch[/switch-model/]
+  end
+
+  scope_gate{Scope Gate}
+  test_gate_lite{Test Gate lite}
+  ux_gate{Accessibility checks queued}
+  test_gate{Test Gate}
+  review_gate{Review Gate}
+  release_gate{Release Gate}
+  hardening_gate{Sev-1 resolved}
+
+  preflight --> plan
+  plan --> scope --> stack --> scope_gate
+  scope_gate --> scaffold
+  scaffold --> api_contract --> openapi --> modular --> test_gate_lite
+  test_gate_lite --> db
+  db --> migrate --> auth --> assets --> screenshots --> ux_gate
+  ux_gate --> e2e --> integration --> coverage --> regression --> test_gate
+  test_gate --> vcs --> devops --> env --> secrets --> iac --> review_gate
+  review_gate --> owners --> review --> review_branch --> pr_desc --> release_notes --> version --> release_gate
+  release_gate --> deploy_staging --> canary --> deploy_prod
+  canary --> rollback
+  deploy_prod --> monitoring --> slo --> logging --> hardening_gate
+  deploy_prod --> error
+  error --> fix --> refactor --> modularity --> deadcode --> cleanup --> flags --> hardening_gate
+  deploy_prod --> flags
+  deploy_prod --> strengths
+  strengths --> evaluation --> compare --> switch
+  flags --> strengths
 ```
 
 ## Future enhancements

--- a/api-contract.md
+++ b/api-contract.md
@@ -23,3 +23,10 @@
 **Notes:**
 
 - Follow JSON:API style for REST unless caller specifies otherwise. Include `429` and `5xx` models.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Test Gate lite — contract checked into repo with sample generation running cleanly.
+- **Previous prompts**: `/scaffold-fullstack`
+- **Next prompts**: `/openapi-generate`, `/modular-architecture`

--- a/api-docs-local.md
+++ b/api-docs-local.md
@@ -13,3 +13,10 @@ Purpose: Fetch API docs and store locally for offline, deterministic reference.
 ## Output format
 
 - Command list and file paths to place docs under `docs/apis/`.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Test Gate lite — contracts cached locally for repeatable generation.
+- **Previous prompts**: `/scaffold-fullstack`
+- **Next prompts**: `/api-contract`, `/openapi-generate`

--- a/auth-scaffold.md
+++ b/auth-scaffold.md
@@ -17,3 +17,10 @@
 **Examples:** `/auth-scaffold oauth` → NextAuth/Passport/Custom adapter plan.
 
 **Notes:** Never print real secrets. Use placeholders in `.env.example`.
+
+## Stage alignment
+
+- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
+- **Gate**: Migration dry-run — auth flows threat-modeled and test accounts wired.
+- **Previous prompts**: `/migration-plan`
+- **Next prompts**: `/modular-architecture`, `/ui-screenshots`, `/e2e-runner-setup`

--- a/cleanup-branches.md
+++ b/cleanup-branches.md
@@ -15,3 +15,10 @@ Example Input:
 Expected Output:
 
 - Structured report following the specified sections.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — repo tidy with stale branches archived.
+- **Previous prompts**: `/dead-code-scan`
+- **Next prompts**: `/feature-flags`, `/model-strengths`

--- a/compare-outputs.md
+++ b/compare-outputs.md
@@ -14,3 +14,10 @@ Purpose: Run multiple models or tools on the same prompt and summarize best outp
 ## Output format
 
 - Matrix comparison and a one-paragraph decision.
+
+## Stage alignment
+
+- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
+- **Gate**: Model uplift — comparative data compiled before switching defaults.
+- **Previous prompts**: `/model-evaluation`
+- **Next prompts**: `/switch-model`

--- a/content-generation.md
+++ b/content-generation.md
@@ -13,3 +13,11 @@ Purpose: Draft docs, blog posts, or marketing copy aligned with the codebase.
 ## Output format
 
 - Markdown files with frontmatter and section headings.
+
+## Stage alignment
+
+- **Phase**: Support communications aligned with
+  [Evidence Log](WORKFLOW.md#11-evidence-log)
+- **Gate**: Ensure docs stay synced with current phase deliverables.
+- **Previous prompts**: Stage-specific work just completed
+- **Next prompts**: `/release-notes`, `/summary` (if sharing updates)

--- a/coverage-guide.md
+++ b/coverage-guide.md
@@ -16,3 +16,10 @@ Example Input:
 Expected Output:
 
 - Focus on src/auth/login.ts — 0% branch coverage; add error path test.
+
+## Stage alignment
+
+- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
+- **Gate**: Test Gate — coverage targets and regression guard plan recorded.
+- **Previous prompts**: `/integration-test`
+- **Next prompts**: `/regression-guard`, `/version-control-guide`

--- a/db-bootstrap.md
+++ b/db-bootstrap.md
@@ -17,3 +17,10 @@
 **Examples:** `/db-bootstrap postgres` → Prisma + Postgres docker-compose.
 
 **Notes:** Avoid destructive defaults; provide `--preview-feature` warnings if relevant.
+
+## Stage alignment
+
+- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
+- **Gate**: Migration dry-run — migrations apply/rollback cleanly with seeds populated.
+- **Previous prompts**: `/modular-architecture`
+- **Next prompts**: `/migration-plan`, `/auth-scaffold`

--- a/dead-code-scan.md
+++ b/dead-code-scan.md
@@ -15,3 +15,10 @@ Example Input:
 Expected Output:
 
 - Structured report following the specified sections.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — ensure code removals keep prod stable.
+- **Previous prompts**: `/file-modularity`
+- **Next prompts**: `/cleanup-branches`, `/feature-flags`

--- a/design-assets.md
+++ b/design-assets.md
@@ -13,3 +13,10 @@ Purpose: Generate favicons and small design snippets from product brand.
 ## Output format
 
 - Asset checklist and generation commands.
+
+## Stage alignment
+
+- **Phase**: [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux)
+- **Gate**: Accessibility checks queued — ensure assets support design review.
+- **Previous prompts**: `/modular-architecture`
+- **Next prompts**: `/ui-screenshots`, `/logging-strategy`

--- a/devops-automation.md
+++ b/devops-automation.md
@@ -14,3 +14,10 @@ Purpose: Configure servers, DNS, SSL, CI/CD at a pragmatic level.
 ## Output format
 
 - Infra plan with checkpoints and secrets placeholders.
+
+## Stage alignment
+
+- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
+- **Gate**: Review Gate — CI pipeline codified, rollback steps rehearsed.
+- **Previous prompts**: `/version-control-guide`
+- **Next prompts**: `/env-setup`, `/secrets-manager-setup`, `/iac-bootstrap`

--- a/e2e-runner-setup.md
+++ b/e2e-runner-setup.md
@@ -15,3 +15,10 @@
 **Examples:** `/e2e-runner-setup playwright`.
 
 **Notes:** Keep runs under 10 minutes locally; parallelize spec files.
+
+## Stage alignment
+
+- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
+- **Gate**: Test Gate — runner green locally and wired into CI before expanding coverage.
+- **Previous prompts**: `/auth-scaffold`, `/ui-screenshots`
+- **Next prompts**: `/integration-test`, `/coverage-guide`

--- a/env-setup.md
+++ b/env-setup.md
@@ -16,3 +16,10 @@
 **Examples:** `/env-setup`.
 
 **Notes:** Do not include real credentials. Enforce `STRICT_ENV=true` in CI.
+
+## Stage alignment
+
+- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
+- **Gate**: Review Gate — environment schemas enforced and CI respects strict loading.
+- **Previous prompts**: `/devops-automation`
+- **Next prompts**: `/secrets-manager-setup`, `/iac-bootstrap`

--- a/error-analysis.md
+++ b/error-analysis.md
@@ -18,3 +18,10 @@ Purpose: Analyze error logs and enumerate likely root causes with fixes.
 ## Examples
 
 - "TypeError: x is not a function" → wrong import, circular dep, stale build.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — Sev-1 incidents triaged with fixes scheduled.
+- **Previous prompts**: `/logging-strategy`, `/audit`
+- **Next prompts**: `/fix`, `/refactor-suggestions`

--- a/explain-code.md
+++ b/explain-code.md
@@ -13,3 +13,11 @@ Purpose: Provide line-by-line explanations for a given file or diff.
 ## Output format
 
 - Annotated markdown with code fences and callouts.
+
+## Stage alignment
+
+- **Phase**: Support — reinforce reviews noted in
+  [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Improve reviewer comprehension before approvals.
+- **Previous prompts**: `/owners`, `/review`
+- **Next prompts**: `/review-branch`, `/pr-desc`

--- a/feature-flags.md
+++ b/feature-flags.md
@@ -15,3 +15,10 @@
 **Examples:** `/feature-flags launchdarkly`.
 
 **Notes:** Ensure flags are typed and expire with tickets.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — guardrails added before toggling new flows.
+- **Previous prompts**: `/cleanup-branches`
+- **Next prompts**: `/model-strengths`, `/model-evaluation`

--- a/file-modularity.md
+++ b/file-modularity.md
@@ -13,3 +13,10 @@ Purpose: Enforce smaller files and propose safe splits for giant files.
 ## Output format
 
 - Refactor plan with patches for file splits.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — structure debt addressed without destabilizing prod.
+- **Previous prompts**: `/refactor-suggestions`
+- **Next prompts**: `/dead-code-scan`, `/cleanup-branches`

--- a/fix.md
+++ b/fix.md
@@ -22,3 +22,10 @@ diff
 ```
 
 Regression test: add case for missing user.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — validated fix with regression coverage before closing incident.
+- **Previous prompts**: `/error-analysis`
+- **Next prompts**: `/refactor-suggestions`, `/file-modularity`

--- a/iac-bootstrap.md
+++ b/iac-bootstrap.md
@@ -16,3 +16,10 @@
 **Examples:** `/iac-bootstrap aws`.
 
 **Notes:** Prefer least privilege IAM and remote state with locking.
+
+## Stage alignment
+
+- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
+- **Gate**: Review Gate — IaC applied in staging with drift detection configured.
+- **Previous prompts**: `/secrets-manager-setup`
+- **Next prompts**: `/owners`, `/review`

--- a/instruction-file.md
+++ b/instruction-file.md
@@ -14,3 +14,10 @@ Purpose: Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` wit
 ## Output format
 
 - Markdown instruction file with stable headings.
+
+## Stage alignment
+
+- **Phase**: [P0 Preflight Docs](WORKFLOW.md#p0-preflight-docs-blocking)
+- **Gate**: DocFetchReport — capture approved instructions before proceeding.
+- **Previous prompts**: Preflight discovery (AGENTS baseline)
+- **Next prompts**: `/planning-process`, `/scope-control`

--- a/integration-test.md
+++ b/integration-test.md
@@ -22,3 +22,10 @@ Purpose: Generate E2E tests that simulate real user flows.
 ## Notes
 
 - Prefer data-test-id attributes. Avoid brittle CSS selectors.
+
+## Stage alignment
+
+- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
+- **Gate**: Test Gate — happy path E2E must pass locally and in CI.
+- **Previous prompts**: `/e2e-runner-setup`
+- **Next prompts**: `/coverage-guide`, `/regression-guard`

--- a/logging-strategy.md
+++ b/logging-strategy.md
@@ -14,3 +14,11 @@ Purpose: Add or remove diagnostic logging cleanly with levels and privacy in min
 ## Output format
 
 - Diff hunks and a short guideline section.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops);
+  coordinate with [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) for client telemetry.
+- **Gate**: Release Gate — logging guardrails ready for canary/production checks.
+- **Previous prompts**: `/monitoring-setup`, `/slo-setup`
+- **Next prompts**: `/audit`, `/error-analysis`

--- a/migration-plan.md
+++ b/migration-plan.md
@@ -15,3 +15,10 @@
 **Examples:** `/migration-plan "orders add status enum"`.
 
 **Notes:** Include online migration strategies for large tables.
+
+## Stage alignment
+
+- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
+- **Gate**: Migration dry-run — validated rollback steps and safety checks documented.
+- **Previous prompts**: `/db-bootstrap`
+- **Next prompts**: `/auth-scaffold`, `/e2e-runner-setup`

--- a/model-evaluation.md
+++ b/model-evaluation.md
@@ -13,3 +13,10 @@ Purpose: Try a new model and compare outputs against a baseline.
 ## Output format
 
 - Summary table and recommendations to adopt or not.
+
+## Stage alignment
+
+- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
+- **Gate**: Model uplift — experiments must beat baseline quality metrics.
+- **Previous prompts**: `/model-strengths`
+- **Next prompts**: `/compare-outputs`, `/switch-model`

--- a/model-strengths.md
+++ b/model-strengths.md
@@ -13,3 +13,10 @@ Purpose: Choose model per task type.
 ## Output format
 
 - Routing guide with examples.
+
+## Stage alignment
+
+- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
+- **Gate**: Model uplift — capture baseline routing before experimentation.
+- **Previous prompts**: `/feature-flags` (optional) or stage-specific blockers.
+- **Next prompts**: `/model-evaluation`, `/compare-outputs`

--- a/modular-architecture.md
+++ b/modular-architecture.md
@@ -14,3 +14,11 @@ Purpose: Enforce modular boundaries and clear external interfaces.
 ## Output format
 
 - Diagram-ready list of modules and edges, plus diffs.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts);
+  revisit during [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) for UI seams.
+- **Gate**: Test Gate lite — boundaries documented and lint/build scripts still pass.
+- **Previous prompts**: `/openapi-generate`
+- **Next prompts**: `/db-bootstrap`, `/ui-screenshots`, `/design-assets`

--- a/monitoring-setup.md
+++ b/monitoring-setup.md
@@ -15,3 +15,10 @@
 **Examples:** `/monitoring-setup`.
 
 **Notes:** Avoid high‑cardinality labels. Sample traces selectively in prod.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Release Gate — observability baselines ready before rollout.
+- **Previous prompts**: `/version-proposal`
+- **Next prompts**: `/slo-setup`, `/logging-strategy`

--- a/openapi-generate.md
+++ b/openapi-generate.md
@@ -17,3 +17,10 @@
 **Examples:** `/openapi-generate client ts apis/auth/openapi.yaml`.
 
 **Notes:** Prefer openapi-typescript + zod for TS clients when possible.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Test Gate lite — generated code builds and CI checks cover the new scripts.
+- **Previous prompts**: `/api-contract`
+- **Next prompts**: `/modular-architecture`, `/db-bootstrap`

--- a/owners.md
+++ b/owners.md
@@ -16,3 +16,10 @@ src/components/Button.tsx
 Expected Output:
 
 - Likely reviewers: @frontend-team (CODEOWNERS), @jane (last 5 commits).
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Review Gate — confirm approvers and escalation paths before PR submission.
+- **Previous prompts**: `/iac-bootstrap`
+- **Next prompts**: `/review`, `/review-branch`, `/pr-desc`

--- a/planning-process.md
+++ b/planning-process.md
@@ -33,3 +33,10 @@ Purpose: Draft, refine, and execute a feature plan with strict scope control and
 
 - Planning only. No code edits.
 - Assume a Git repo with test runner available.
+
+## Stage alignment
+
+- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
+- **Gate**: Scope Gate — confirm problem, users, Done criteria, and stack risks are logged.
+- **Previous prompts**: Preflight Docs (AGENTS baseline)
+- **Next prompts**: `/scope-control`, `/stack-evaluation`

--- a/pr-desc.md
+++ b/pr-desc.md
@@ -17,3 +17,10 @@ src/example.ts
 Expected Output:
 
 - Actionable summary aligned with the output section.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Review Gate — PR narrative ready for approvals and release prep.
+- **Previous prompts**: `/review-branch`
+- **Next prompts**: `/release-notes`, `/version-proposal`

--- a/prototype-feature.md
+++ b/prototype-feature.md
@@ -14,3 +14,11 @@ Purpose: Spin up a standalone prototype in a clean repo before merging into main
 ## Output format
 
 - Scaffold plan and migration notes.
+
+## Stage alignment
+
+- **Phase**: Sandbox between [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope) and
+  [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Validate spike outcomes before committing to scope.
+- **Previous prompts**: `/planning-process`
+- **Next prompts**: `/scaffold-fullstack`, `/api-contract`

--- a/refactor-suggestions.md
+++ b/refactor-suggestions.md
@@ -13,3 +13,10 @@ Purpose: Propose repo-wide refactoring opportunities after tests exist.
 ## Output format
 
 - Ranked list with owners and effort estimates.
+
+## Stage alignment
+
+- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
+- **Gate**: Post-release cleanup — plan high-leverage refactors once Sev-1 issues settle.
+- **Previous prompts**: `/fix`
+- **Next prompts**: `/file-modularity`, `/dead-code-scan`

--- a/reference-implementation.md
+++ b/reference-implementation.md
@@ -13,3 +13,10 @@ Purpose: Mimic the style and API of a known working example.
 ## Output format
 
 - Side-by-side API table and patch suggestions.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Test Gate lite — align new modules with proven patterns before deeper work.
+- **Previous prompts**: `/scaffold-fullstack`, `/api-contract`
+- **Next prompts**: `/modular-architecture`, `/openapi-generate`

--- a/regression-guard.md
+++ b/regression-guard.md
@@ -17,3 +17,10 @@ Purpose: Detect unrelated changes and add tests to prevent regressions.
 ## Notes
 
 - Keep proposed tests minimal and focused.
+
+## Stage alignment
+
+- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
+- **Gate**: Test Gate — regression coverage in place before CI hand-off.
+- **Previous prompts**: `/coverage-guide`
+- **Next prompts**: `/version-control-guide`, `/devops-automation`

--- a/release-notes.md
+++ b/release-notes.md
@@ -20,3 +20,10 @@ Expected Output:
 ## Fixes
 
 - Resolve logout crash (PR #57)
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Release Gate — notes compiled for staging review and production rollout.
+- **Previous prompts**: `/pr-desc`
+- **Next prompts**: `/version-proposal`, `/monitoring-setup`

--- a/reset-strategy.md
+++ b/reset-strategy.md
@@ -22,3 +22,10 @@ Purpose: Decide when to hard reset and start clean to avoid layered bad diffs.
 ## Notes
 
 - Warn about destructive nature. Require user confirmation.
+
+## Stage alignment
+
+- **Phase**: [Reset Playbook](WORKFLOW.md#reset-playbook)
+- **Gate**: Clean restart — triggered when gate criteria stall for >60 minutes.
+- **Previous prompts**: Any blocked stage
+- **Next prompts**: Restart with `/planning-process` then follow the gated flow

--- a/review-branch.md
+++ b/review-branch.md
@@ -16,3 +16,10 @@ Example Input:
 Expected Output:
 
 - Structured report following the specified sections.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Review Gate — branch scope validated before PR submission.
+- **Previous prompts**: `/review`
+- **Next prompts**: `/pr-desc`, `/release-notes`

--- a/review.md
+++ b/review.md
@@ -16,3 +16,10 @@ HttpClient
 Expected Output:
 
 - Usage cluster in src/network/* with note on inconsistent error handling.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Review Gate — peer review coverage met before merging.
+- **Previous prompts**: `/owners`
+- **Next prompts**: `/review-branch`, `/pr-desc`

--- a/scaffold-fullstack.md
+++ b/scaffold-fullstack.md
@@ -40,3 +40,10 @@
 
 - Assume pnpm and Node 20+. Do not run package installs automatically; propose commands instead.
 - Respect existing files; avoid overwriting without explicit confirmation.
+
+## Stage alignment
+
+- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
+- **Gate**: Test Gate lite — ensure lint/build scripts execute on the generated scaffold.
+- **Previous prompts**: `/stack-evaluation`
+- **Next prompts**: `/api-contract`, `/openapi-generate`, `/modular-architecture`

--- a/scope-control.md
+++ b/scope-control.md
@@ -22,3 +22,10 @@ Output: Move to **Ideas for later** with reason "Not needed for OAuth MVP".
 ## Notes
 
 - Never add new scope without recording tradeoffs.
+
+## Stage alignment
+
+- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
+- **Gate**: Scope Gate — Done criteria, scope lists, and stack choices are committed.
+- **Previous prompts**: `/planning-process`
+- **Next prompts**: `/stack-evaluation`, `/scaffold-fullstack`

--- a/secrets-manager-setup.md
+++ b/secrets-manager-setup.md
@@ -15,3 +15,10 @@
 **Examples:** `/secrets-manager-setup doppler`.
 
 **Notes:** Never echo secret values. Include rotation policy.
+
+## Stage alignment
+
+- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
+- **Gate**: Review Gate — secret paths mapped and least-privilege policies drafted.
+- **Previous prompts**: `/env-setup`
+- **Next prompts**: `/iac-bootstrap`, `/owners`

--- a/slo-setup.md
+++ b/slo-setup.md
@@ -15,3 +15,10 @@
 **Examples:** `/slo-setup`.
 
 **Notes:** Tie SLOs to deploy gates and incident severity.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Release Gate — SLOs and alerts reviewed before production rollout.
+- **Previous prompts**: `/monitoring-setup`
+- **Next prompts**: `/logging-strategy`, `/audit`

--- a/stack-evaluation.md
+++ b/stack-evaluation.md
@@ -13,3 +13,10 @@ Purpose: Evaluate language/framework choices relative to AI familiarity and repo
 ## Output format
 
 - Decision memo with pros/cons and next steps.
+
+## Stage alignment
+
+- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
+- **Gate**: Scope Gate — record recommended stack and top risks before building.
+- **Previous prompts**: `/scope-control`
+- **Next prompts**: `/scaffold-fullstack`, `/api-contract`

--- a/switch-model.md
+++ b/switch-model.md
@@ -14,3 +14,10 @@ Purpose: Decide when to try a different AI backend and how to compare.
 ## Output format
 
 - Table: task → model → settings → win reason.
+
+## Stage alignment
+
+- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
+- **Gate**: Model uplift — document rollback/guardrails before flipping defaults.
+- **Previous prompts**: `/compare-outputs`
+- **Next prompts**: Return to the blocked stage (e.g., `/integration-test`) to apply learnings.

--- a/ui-screenshots.md
+++ b/ui-screenshots.md
@@ -13,3 +13,10 @@ Purpose: Analyze screenshots for UI bugs or inspiration and propose actionable U
 ## Output format
 
 - Issue list and code snippets to fix visuals.
+
+## Stage alignment
+
+- **Phase**: [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux)
+- **Gate**: Accessibility checks queued — capture UX issues and backlog fixes.
+- **Previous prompts**: `/design-assets`, `/modular-architecture`
+- **Next prompts**: `/logging-strategy`, `/e2e-runner-setup`

--- a/version-control-guide.md
+++ b/version-control-guide.md
@@ -22,3 +22,10 @@ Purpose: Enforce clean incremental commits and clean-room re-implementation when
 ## Notes
 
 - Never modify remote branches without confirmation.
+
+## Stage alignment
+
+- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
+- **Gate**: Review Gate — clean diff, CI green, and approvals ready.
+- **Previous prompts**: `/regression-guard`
+- **Next prompts**: `/devops-automation`, `/env-setup`

--- a/version-proposal.md
+++ b/version-proposal.md
@@ -16,3 +16,10 @@ Example Input:
 Expected Output:
 
 - Structured report following the specified sections.
+
+## Stage alignment
+
+- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
+- **Gate**: Release Gate — version bump decision recorded before deployment.
+- **Previous prompts**: `/release-notes`
+- **Next prompts**: `/monitoring-setup`, `/slo-setup`

--- a/voice-input.md
+++ b/voice-input.md
@@ -13,3 +13,11 @@ Purpose: Support interaction from voice capture and convert to structured prompt
 ## Output format
 
 - Cleaned command list ready to execute.
+
+## Stage alignment
+
+- **Phase**: Support — accelerates transitions between stages documented in
+  [WORKFLOW.md](WORKFLOW.md)
+- **Gate**: Clarify voice-derived requests before invoking gated prompts.
+- **Previous prompts**: Voice transcript capture
+- **Next prompts**: Any stage-specific command (e.g., `/planning-process`)

--- a/workflow.mmd
+++ b/workflow.mmd
@@ -1,53 +1,107 @@
 flowchart TD
-    A[planning-process.md] --> B[scope-control.md]
-    B --> C[prototype-feature.md]
-    C --> D[explain-code.md]
-    D --> E[refactor-file.md]
-    E --> F[file-modularity.md]
-    F --> G[generate.md]
-    G --> H[integration-test.md]
-    H --> I[coverage-guide.md]
-    I --> J[explain-failures.md]
-    J --> K[fix.md]
-    K --> L[commit.md]
-    L --> M[review.md]
-    M --> N[review-branch.md]
-    N --> O[pr-desc.md]
-    O --> P[regression-guard.md]
-    P --> Q[release-notes.md]
-    Q --> R[version-proposal.md]
-    R --> S[devops-automation.md]
-    S --> T[reset-strategy.md]
-    T --> U[cleanup-branches.md]
-    U --> V[design-assets.md]
-    V --> W[ui-screenshots.md]
-    W --> X[logging-strategy.md]
-    X --> Y[error-analysis.md]
-    Y --> Z[audit.md]
-    Z --> AA[summary.md]
-    AA --> AB[instruction-file.md]
-    AB --> AC[version-control-guide.md]
-    AC --> AD[owners.md]
-    AD --> AE[blame-summary.md]
-    AE --> AF[changed-files.md]
-    AF --> AG[todo-report.md]
-    AG --> AH[todos.md]
-    AH --> AI[dead-code-scan.md]
-    AI --> AJ[grep.md]
-    AJ --> AK[explain-symbol.md]
-    AK --> AL[api-usage.md]
-    AL --> AM[action-diagram.md]
-    AM --> AN[plan.md]
-    AN --> AO[tsconfig-review.md]
-    AO --> AP[eslint-review.md]
-    AP --> AQ[stack-evaluation.md]
-    AQ --> AR[modular-architecture.md]
-    AR --> AS[refactor-suggestions.md]
-    AS --> AT[reference-implementation.md]
-    AT --> AU[model-strengths.md]
-    AU --> AV[model-evaluation.md]
-    AV --> AW[compare-outputs.md]
-    AW --> AX[switch-model.md]
-    AX --> AY[voice-input.md]
-    AY --> AZ[content-generation.md]
-    AZ --> BA[api-docs-local.md]
+  subgraph P0["P0 Preflight Docs"]
+    preflight["Preflight Docs (§A) AGENTS"]
+  end
+
+  subgraph P1["P1 Plan & Scope"]
+    plan[/planning-process/]
+    scope[/scope-control/]
+    stack[/stack-evaluation/]
+  end
+
+  subgraph P2["P2 App Scaffold & Contracts"]
+    scaffold[/scaffold-fullstack/]
+    api_contract[/api-contract/]
+    openapi[/openapi-generate/]
+    modular[/modular-architecture/]
+  end
+
+  subgraph P3["P3 Data & Auth"]
+    db[/db-bootstrap/]
+    migrate[/migration-plan/]
+    auth[/auth-scaffold/]
+  end
+
+  subgraph P4["P4 Frontend UX"]
+    assets[/design-assets/]
+    screenshots[/ui-screenshots/]
+  end
+
+  subgraph P5["P5 Quality Gates & Tests"]
+    e2e[/e2e-runner-setup/]
+    integration[/integration-test/]
+    coverage[/coverage-guide/]
+    regression[/regression-guard/]
+  end
+
+  subgraph P6["P6 CI/CD & Env"]
+    vcs[/version-control-guide/]
+    devops[/devops-automation/]
+    env[/env-setup/]
+    secrets[/secrets-manager-setup/]
+    iac[/iac-bootstrap/]
+  end
+
+  subgraph P7["P7 Release & Ops"]
+    owners[/owners/]
+    review[/review/]
+    review_branch[/review-branch/]
+    pr_desc[/pr-desc/]
+    release_notes[/release-notes/]
+    version[/version-proposal/]
+    monitoring[/monitoring-setup/]
+    slo[/slo-setup/]
+    logging[/logging-strategy/]
+    audit[/audit/]
+  end
+
+  subgraph Deploy["Deployment Flow"]
+    deploy_staging[Deploy Staging]
+    canary[Canary + Health]
+    deploy_prod[Deploy Prod]
+    rollback[Rollback]
+  end
+
+  subgraph P8["P8 Post-release Hardening"]
+    error[/error-analysis/]
+    fix[/fix/]
+    refactor[/refactor-suggestions/]
+    modularity[/file-modularity/]
+    deadcode[/dead-code-scan/]
+    cleanup[/cleanup-branches/]
+    flags[/feature-flags/]
+  end
+
+  subgraph P9["P9 Model Tactics"]
+    strengths[/model-strengths/]
+    evaluation[/model-evaluation/]
+    compare[/compare-outputs/]
+    switch[/switch-model/]
+  end
+
+  scope_gate{Scope Gate}
+  test_gate_lite{Test Gate lite}
+  ux_gate{Accessibility checks queued}
+  test_gate{Test Gate}
+  review_gate{Review Gate}
+  release_gate{Release Gate}
+  hardening_gate{Sev-1 resolved}
+
+  preflight --> plan
+  plan --> scope --> stack --> scope_gate
+  scope_gate --> scaffold
+  scaffold --> api_contract --> openapi --> modular --> test_gate_lite
+  test_gate_lite --> db
+  db --> migrate --> auth --> assets --> screenshots --> ux_gate
+  ux_gate --> e2e --> integration --> coverage --> regression --> test_gate
+  test_gate --> vcs --> devops --> env --> secrets --> iac --> review_gate
+  review_gate --> owners --> review --> review_branch --> pr_desc --> release_notes --> version --> release_gate
+  release_gate --> deploy_staging --> canary --> deploy_prod
+  canary --> rollback
+  deploy_prod --> monitoring --> slo --> logging --> audit --> hardening_gate
+  deploy_prod --> error
+  error --> fix --> refactor --> modularity --> deadcode --> cleanup --> flags --> hardening_gate
+  deploy_prod --> flags
+  deploy_prod --> strengths
+  strengths --> evaluation --> compare --> switch
+  flags --> strengths


### PR DESCRIPTION
## Summary
- add explicit "Stage alignment" blocks to core slash prompts with phase, gate, and navigation links
- reorganize the README core commands index by development phase and update the workflow diagram
- reshape workflow.mmd into phase subgraphs with gate nodes that mirror WORKFLOW.md

## Testing
- npx --yes markdownlint-cli2 "**/*.md" *(fails: repository already has existing lint violations in untouched docs)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8eedccfc83288c37a90325c21087