### PR TITLE
Add lifecycle metadata front matter and validator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Thanks for helping extend the prompt catalog. Follow these guidelines so metadata stays consistent with the lifecycle workflow.
+
+## Metadata expectations
+
+- Every lifecycle prompt must begin with the YAML front matter documented in [README.md](README.md).
+- `phase` values must reference headings from [WORKFLOW.md](WORKFLOW.md). Use an array when the prompt spans multiple phases.
+- Keep `previous` and `next` arrays focused on slash commands or named prerequisites.
+
+## Validation
+
+1. Install dev dependencies once: `npm install`.
+2. Run the metadata check before adding or editing prompts: `npm run validate:metadata`.
+3. Fix any reported issues before opening a PR.
+
+The validator ensures front matter stays in sync with the workflow gates and stops regressions early.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ This pack extends the default Codex CLI prompts with vibe-coding playbooks inspi
 - **Direct slash commands**: Invoke the files that declare a `Trigger:` (table below) straight from Codex. Example: `/planning-process Add OAuth login` opens `planning-process.md` and walks through the feature plan template.
 - **Gemini mapper prompt**: `/gemini-map` is a single translator prompt (`gemini-map.md`) that converts Gemini CLI TOML commands into Codex prompt files. Use it only when migrating Gemini content; all other prompts run directly with their own slash commands.
 
+## Prompt metadata
+
+Every lifecycle prompt starts with YAML front matter so docs and tooling stay in sync:
+
+```yaml
+---
+phase: "P5 Quality Gates & Tests"
+gate: "Test Gate"
+status: "Runner green locally and wired into CI before expanding coverage."
+previous:
+  - "/auth-scaffold"
+  - "/ui-screenshots"
+next:
+  - "/integration-test"
+  - "/coverage-guide"
+---
+```
+
+- `phase` — primary stage(s) from [WORKFLOW.md](WORKFLOW.md). Use a string for a single phase or a YAML list for cross-phase helpers.
+- `gate` — named gate or checkpoint the prompt supports.
+- `status` — the success criteria required to pass that gate.
+- `previous` — prerequisite prompts or setup tasks.
+- `next` — recommended follow-up prompts once the gate clears.
+
+Maintainers and the metadata validator rely on this block to keep the stage catalog coherent.
+
 ## Core slash commands
 
 Commands are grouped by development phase. Stage headings link back to

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -277,6 +277,12 @@ flowchart TD
 **When**: Contentious generation, flaky refactors, new model availability.
 **Steps**: `/model-strengths` → route candidates. `/model-evaluation` → baseline vs new. `/compare-outputs` → pick best. `/switch-model` → roll change with guardrails. Success = higher test pass rate or smaller diff with same tests.&#x20;
 
+## Support
+
+**Purpose**: Cross-cutting helpers that smooth transitions between gated stages.
+**Steps**: `/voice-input` → turn transcripts into structured prompts. `/content-generation` → broadcast updates aligned with the Evidence Log.
+**Gate**: Clarify requests before triggering lifecycle prompts and keep documentation current with delivered work.
+
 ---
 
 **Notes**

--- a/api-contract.md
+++ b/api-contract.md
@@ -1,3 +1,14 @@
+---
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "contract checked into repo with sample generation running cleanly."
+previous:
+  - "/scaffold-fullstack"
+next:
+  - "/openapi-generate"
+  - "/modular-architecture"
+---
+
 # API Contract
 
 **Trigger:** `/api-contract "<feature or domain>"`
@@ -24,9 +35,3 @@
 
 - Follow JSON:API style for REST unless caller specifies otherwise. Include `429` and `5xx` models.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Test Gate lite — contract checked into repo with sample generation running cleanly.
-- **Previous prompts**: `/scaffold-fullstack`
-- **Next prompts**: `/openapi-generate`, `/modular-architecture`

--- a/api-docs-local.md
+++ b/api-docs-local.md
@@ -1,3 +1,14 @@
+---
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "contracts cached locally for repeatable generation."
+previous:
+  - "/scaffold-fullstack"
+next:
+  - "/api-contract"
+  - "/openapi-generate"
+---
+
 # API Docs Local
 
 Trigger: /api-docs-local
@@ -14,9 +25,3 @@ Purpose: Fetch API docs and store locally for offline, deterministic reference.
 
 - Command list and file paths to place docs under `docs/apis/`.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Test Gate lite — contracts cached locally for repeatable generation.
-- **Previous prompts**: `/scaffold-fullstack`
-- **Next prompts**: `/api-contract`, `/openapi-generate`

--- a/audit.md
+++ b/audit.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "readiness criteria before shipping."
+previous:
+  - "/logging-strategy"
+next:
+  - "/error-analysis"
+  - "/fix"
+---
+
 # Audit
 
 Trigger: /audit
@@ -25,9 +36,3 @@ Purpose: Audit repository hygiene and suggest improvements.
 
 - Structured report following the specified sections.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Release Gate — readiness criteria before shipping.
-- **Previous prompts**: `/logging-strategy`
-- **Next prompts**: `/error-analysis`, `/fix`

--- a/auth-scaffold.md
+++ b/auth-scaffold.md
@@ -1,3 +1,15 @@
+---
+phase: "P3 Data & Auth"
+gate: "Migration dry-run"
+status: "auth flows threat-modeled and test accounts wired."
+previous:
+  - "/migration-plan"
+next:
+  - "/modular-architecture"
+  - "/ui-screenshots"
+  - "/e2e-runner-setup"
+---
+
 # Auth Scaffold
 
 **Trigger:** `/auth-scaffold <oauth|email|oidc>`
@@ -18,9 +30,3 @@
 
 **Notes:** Never print real secrets. Use placeholders in `.env.example`.
 
-## Stage alignment
-
-- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
-- **Gate**: Migration dry-run — auth flows threat-modeled and test accounts wired.
-- **Previous prompts**: `/migration-plan`
-- **Next prompts**: `/modular-architecture`, `/ui-screenshots`, `/e2e-runner-setup`

--- a/cleanup-branches.md
+++ b/cleanup-branches.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "repo tidy with stale branches archived."
+previous:
+  - "/dead-code-scan"
+next:
+  - "/feature-flags"
+  - "/model-strengths"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Suggest safe local branch cleanup (merged/stale).
 
 1. Gather context by running `git branch --merged` for the merged into current upstream; running `git branch --no-merged` for the branches not merged; running `git for-each-ref --sort=-authordate --format='%(refname:short) — %(authordate:relative)' refs/heads` for the recently updated (last author dates).
@@ -16,9 +27,3 @@ Expected Output:
 
 - Structured report following the specified sections.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — repo tidy with stale branches archived.
-- **Previous prompts**: `/dead-code-scan`
-- **Next prompts**: `/feature-flags`, `/model-strengths`

--- a/compare-outputs.md
+++ b/compare-outputs.md
@@ -1,3 +1,13 @@
+---
+phase: "P9 Model Tactics"
+gate: "Model uplift"
+status: "comparative data compiled before switching defaults."
+previous:
+  - "/model-evaluation"
+next:
+  - "/switch-model"
+---
+
 # Compare Outputs
 
 Trigger: /compare-outputs
@@ -15,9 +25,3 @@ Purpose: Run multiple models or tools on the same prompt and summarize best outp
 
 - Matrix comparison and a one-paragraph decision.
 
-## Stage alignment
-
-- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
-- **Gate**: Model uplift — comparative data compiled before switching defaults.
-- **Previous prompts**: `/model-evaluation`
-- **Next prompts**: `/switch-model`

--- a/content-generation.md
+++ b/content-generation.md
@@ -1,3 +1,14 @@
+---
+phase: "11) Evidence Log"
+gate: "Evidence Log"
+status: "Ensure docs stay synced with current phase deliverables."
+previous:
+  - "Stage-specific work just completed"
+next:
+  - "/release-notes"
+  - "/summary (if sharing updates)"
+---
+
 # Content Generation
 
 Trigger: /content-generation
@@ -14,10 +25,3 @@ Purpose: Draft docs, blog posts, or marketing copy aligned with the codebase.
 
 - Markdown files with frontmatter and section headings.
 
-## Stage alignment
-
-- **Phase**: Support communications aligned with
-  [Evidence Log](WORKFLOW.md#11-evidence-log)
-- **Gate**: Ensure docs stay synced with current phase deliverables.
-- **Previous prompts**: Stage-specific work just completed
-- **Next prompts**: `/release-notes`, `/summary` (if sharing updates)

--- a/coverage-guide.md
+++ b/coverage-guide.md
@@ -1,3 +1,14 @@
+---
+phase: "P5 Quality Gates & Tests"
+gate: "Test Gate"
+status: "coverage targets and regression guard plan recorded."
+previous:
+  - "/integration-test"
+next:
+  - "/regression-guard"
+  - "/version-control-guide"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Suggest a plan to raise coverage based on uncovered areas.
 
 1. Gather context by running `find . -name 'coverage*' -type f -maxdepth 3 -print -exec head -n 40 {} \; 2>/dev/null` for the coverage hints; running `git ls-files | sed -n '1,400p'` for the repo map.
@@ -17,9 +28,3 @@ Expected Output:
 
 - Focus on src/auth/login.ts — 0% branch coverage; add error path test.
 
-## Stage alignment
-
-- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
-- **Gate**: Test Gate — coverage targets and regression guard plan recorded.
-- **Previous prompts**: `/integration-test`
-- **Next prompts**: `/regression-guard`, `/version-control-guide`

--- a/db-bootstrap.md
+++ b/db-bootstrap.md
@@ -1,3 +1,14 @@
+---
+phase: "P3 Data & Auth"
+gate: "Migration dry-run"
+status: "migrations apply/rollback cleanly with seeds populated."
+previous:
+  - "/modular-architecture"
+next:
+  - "/migration-plan"
+  - "/auth-scaffold"
+---
+
 # DB Bootstrap
 
 **Trigger:** `/db-bootstrap <postgres|mysql|sqlite|mongodb>`
@@ -18,9 +29,3 @@
 
 **Notes:** Avoid destructive defaults; provide `--preview-feature` warnings if relevant.
 
-## Stage alignment
-
-- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
-- **Gate**: Migration dry-run — migrations apply/rollback cleanly with seeds populated.
-- **Previous prompts**: `/modular-architecture`
-- **Next prompts**: `/migration-plan`, `/auth-scaffold`

--- a/dead-code-scan.md
+++ b/dead-code-scan.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "ensure code removals keep prod stable."
+previous:
+  - "/file-modularity"
+next:
+  - "/cleanup-branches"
+  - "/feature-flags"
+---
+
 You are a CLI assistant focused on helping contributors with the task: List likely dead or unused files and exports (static signals).
 
 1. Gather context by running `rg -n "export |module.exports|exports\.|require\(|import " -g '!node_modules' .` for the file reference graph (best‑effort).
@@ -16,9 +27,3 @@ Expected Output:
 
 - Structured report following the specified sections.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — ensure code removals keep prod stable.
-- **Previous prompts**: `/file-modularity`
-- **Next prompts**: `/cleanup-branches`, `/feature-flags`

--- a/design-assets.md
+++ b/design-assets.md
@@ -1,3 +1,14 @@
+---
+phase: "P4 Frontend UX"
+gate: "Accessibility checks queued"
+status: "ensure assets support design review."
+previous:
+  - "/modular-architecture"
+next:
+  - "/ui-screenshots"
+  - "/logging-strategy"
+---
+
 # Design Assets
 
 Trigger: /design-assets
@@ -14,9 +25,3 @@ Purpose: Generate favicons and small design snippets from product brand.
 
 - Asset checklist and generation commands.
 
-## Stage alignment
-
-- **Phase**: [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux)
-- **Gate**: Accessibility checks queued — ensure assets support design review.
-- **Previous prompts**: `/modular-architecture`
-- **Next prompts**: `/ui-screenshots`, `/logging-strategy`

--- a/devops-automation.md
+++ b/devops-automation.md
@@ -1,3 +1,15 @@
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "CI pipeline codified, rollback steps rehearsed."
+previous:
+  - "/version-control-guide"
+next:
+  - "/env-setup"
+  - "/secrets-manager-setup"
+  - "/iac-bootstrap"
+---
+
 # DevOps Automation
 
 Trigger: /devops-automation
@@ -15,9 +27,3 @@ Purpose: Configure servers, DNS, SSL, CI/CD at a pragmatic level.
 
 - Infra plan with checkpoints and secrets placeholders.
 
-## Stage alignment
-
-- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
-- **Gate**: Review Gate — CI pipeline codified, rollback steps rehearsed.
-- **Previous prompts**: `/version-control-guide`
-- **Next prompts**: `/env-setup`, `/secrets-manager-setup`, `/iac-bootstrap`

--- a/e2e-runner-setup.md
+++ b/e2e-runner-setup.md
@@ -1,3 +1,15 @@
+---
+phase: "P5 Quality Gates & Tests"
+gate: "Test Gate"
+status: "runner green locally and wired into CI before expanding coverage."
+previous:
+  - "/auth-scaffold"
+  - "/ui-screenshots"
+next:
+  - "/integration-test"
+  - "/coverage-guide"
+---
+
 # E2E Runner Setup
 
 **Trigger:** `/e2e-runner-setup <playwright|cypress>`
@@ -16,9 +28,3 @@
 
 **Notes:** Keep runs under 10 minutes locally; parallelize spec files.
 
-## Stage alignment
-
-- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
-- **Gate**: Test Gate — runner green locally and wired into CI before expanding coverage.
-- **Previous prompts**: `/auth-scaffold`, `/ui-screenshots`
-- **Next prompts**: `/integration-test`, `/coverage-guide`

--- a/env-setup.md
+++ b/env-setup.md
@@ -1,3 +1,14 @@
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "environment schemas enforced and CI respects strict loading."
+previous:
+  - "/devops-automation"
+next:
+  - "/secrets-manager-setup"
+  - "/iac-bootstrap"
+---
+
 # Env Setup
 
 **Trigger:** `/env-setup`
@@ -17,9 +28,3 @@
 
 **Notes:** Do not include real credentials. Enforce `STRICT_ENV=true` in CI.
 
-## Stage alignment
-
-- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
-- **Gate**: Review Gate — environment schemas enforced and CI respects strict loading.
-- **Previous prompts**: `/devops-automation`
-- **Next prompts**: `/secrets-manager-setup`, `/iac-bootstrap`

--- a/error-analysis.md
+++ b/error-analysis.md
@@ -1,3 +1,15 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "Sev-1 incidents triaged with fixes scheduled."
+previous:
+  - "/logging-strategy"
+  - "/audit"
+next:
+  - "/fix"
+  - "/refactor-suggestions"
+---
+
 # Error Analysis
 
 Trigger: /error-analysis
@@ -19,9 +31,3 @@ Purpose: Analyze error logs and enumerate likely root causes with fixes.
 
 - "TypeError: x is not a function" → wrong import, circular dep, stale build.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — Sev-1 incidents triaged with fixes scheduled.
-- **Previous prompts**: `/logging-strategy`, `/audit`
-- **Next prompts**: `/fix`, `/refactor-suggestions`

--- a/explain-code.md
+++ b/explain-code.md
@@ -1,3 +1,15 @@
+---
+phase: "P7 Release & Ops"
+gate: "Review Gate"
+status: "Improve reviewer comprehension before approvals."
+previous:
+  - "/owners"
+  - "/review"
+next:
+  - "/review-branch"
+  - "/pr-desc"
+---
+
 # Explain Code
 
 Trigger: /explain-code
@@ -14,10 +26,3 @@ Purpose: Provide line-by-line explanations for a given file or diff.
 
 - Annotated markdown with code fences and callouts.
 
-## Stage alignment
-
-- **Phase**: Support — reinforce reviews noted in
-  [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Improve reviewer comprehension before approvals.
-- **Previous prompts**: `/owners`, `/review`
-- **Next prompts**: `/review-branch`, `/pr-desc`

--- a/feature-flags.md
+++ b/feature-flags.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "guardrails added before toggling new flows."
+previous:
+  - "/cleanup-branches"
+next:
+  - "/model-strengths"
+  - "/model-evaluation"
+---
+
 # Feature Flags
 
 **Trigger:** `/feature-flags <provider>`
@@ -16,9 +27,3 @@
 
 **Notes:** Ensure flags are typed and expire with tickets.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — guardrails added before toggling new flows.
-- **Previous prompts**: `/cleanup-branches`
-- **Next prompts**: `/model-strengths`, `/model-evaluation`

--- a/file-modularity.md
+++ b/file-modularity.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "structure debt addressed without destabilizing prod."
+previous:
+  - "/refactor-suggestions"
+next:
+  - "/dead-code-scan"
+  - "/cleanup-branches"
+---
+
 # File Modularity
 
 Trigger: /file-modularity
@@ -14,9 +25,3 @@ Purpose: Enforce smaller files and propose safe splits for giant files.
 
 - Refactor plan with patches for file splits.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — structure debt addressed without destabilizing prod.
-- **Previous prompts**: `/refactor-suggestions`
-- **Next prompts**: `/dead-code-scan`, `/cleanup-branches`

--- a/fix.md
+++ b/fix.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "validated fix with regression coverage before closing incident."
+previous:
+  - "/error-analysis"
+next:
+  - "/refactor-suggestions"
+  - "/file-modularity"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Propose a minimal, correct fix with patch hunks.
 
 1. Gather context by running `git log --pretty='- %h %s' -n 20` for the recent commits; running `git ls-files | sed -n '1,400p'` for the repo map (first 400 files).
@@ -23,9 +34,3 @@ diff
 
 Regression test: add case for missing user.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — validated fix with regression coverage before closing incident.
-- **Previous prompts**: `/error-analysis`
-- **Next prompts**: `/refactor-suggestions`, `/file-modularity`

--- a/iac-bootstrap.md
+++ b/iac-bootstrap.md
@@ -1,3 +1,14 @@
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "IaC applied in staging with drift detection configured."
+previous:
+  - "/secrets-manager-setup"
+next:
+  - "/owners"
+  - "/review"
+---
+
 # IaC Bootstrap
 
 **Trigger:** `/iac-bootstrap <aws|gcp|azure|fly|render>`
@@ -17,9 +28,3 @@
 
 **Notes:** Prefer least privilege IAM and remote state with locking.
 
-## Stage alignment
-
-- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
-- **Gate**: Review Gate — IaC applied in staging with drift detection configured.
-- **Previous prompts**: `/secrets-manager-setup`
-- **Next prompts**: `/owners`, `/review`

--- a/instruction-file.md
+++ b/instruction-file.md
@@ -1,3 +1,14 @@
+---
+phase: "P0 Preflight Docs"
+gate: "DocFetchReport"
+status: "capture approved instructions before proceeding."
+previous:
+  - "Preflight discovery (AGENTS baseline)"
+next:
+  - "/planning-process"
+  - "/scope-control"
+---
+
 # Instruction File
 
 Trigger: /instruction-file
@@ -15,9 +26,3 @@ Purpose: Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` wit
 
 - Markdown instruction file with stable headings.
 
-## Stage alignment
-
-- **Phase**: [P0 Preflight Docs](WORKFLOW.md#p0-preflight-docs-blocking)
-- **Gate**: DocFetchReport — capture approved instructions before proceeding.
-- **Previous prompts**: Preflight discovery (AGENTS baseline)
-- **Next prompts**: `/planning-process`, `/scope-control`

--- a/integration-test.md
+++ b/integration-test.md
@@ -1,3 +1,14 @@
+---
+phase: "P5 Quality Gates & Tests"
+gate: "Test Gate"
+status: "happy path E2E must pass locally and in CI."
+previous:
+  - "/e2e-runner-setup"
+next:
+  - "/coverage-guide"
+  - "/regression-guard"
+---
+
 # Integration Test
 
 Trigger: /integration-test
@@ -23,9 +34,3 @@ Purpose: Generate E2E tests that simulate real user flows.
 
 - Prefer data-test-id attributes. Avoid brittle CSS selectors.
 
-## Stage alignment
-
-- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
-- **Gate**: Test Gate — happy path E2E must pass locally and in CI.
-- **Previous prompts**: `/e2e-runner-setup`
-- **Next prompts**: `/coverage-guide`, `/regression-guard`

--- a/logging-strategy.md
+++ b/logging-strategy.md
@@ -1,3 +1,14 @@
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "logging guardrails ready for canary/production checks; coordinate with P4 Frontend UX for client telemetry."
+previous:
+  - "/monitoring-setup"
+  - "/slo-setup"
+next:
+  - "/audit"
+  - "/error-analysis"
+---
+
 # Logging Strategy
 
 Trigger: /logging-strategy
@@ -15,10 +26,3 @@ Purpose: Add or remove diagnostic logging cleanly with levels and privacy in min
 
 - Diff hunks and a short guideline section.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops);
-  coordinate with [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) for client telemetry.
-- **Gate**: Release Gate — logging guardrails ready for canary/production checks.
-- **Previous prompts**: `/monitoring-setup`, `/slo-setup`
-- **Next prompts**: `/audit`, `/error-analysis`

--- a/migration-plan.md
+++ b/migration-plan.md
@@ -1,3 +1,14 @@
+---
+phase: "P3 Data & Auth"
+gate: "Migration dry-run"
+status: "validated rollback steps and safety checks documented."
+previous:
+  - "/db-bootstrap"
+next:
+  - "/auth-scaffold"
+  - "/e2e-runner-setup"
+---
+
 # Migration Plan
 
 **Trigger:** `/migration-plan "<change summary>"`
@@ -16,9 +27,3 @@
 
 **Notes:** Include online migration strategies for large tables.
 
-## Stage alignment
-
-- **Phase**: [P3 Data & Auth](WORKFLOW.md#p3-data--auth)
-- **Gate**: Migration dry-run — validated rollback steps and safety checks documented.
-- **Previous prompts**: `/db-bootstrap`
-- **Next prompts**: `/auth-scaffold`, `/e2e-runner-setup`

--- a/model-evaluation.md
+++ b/model-evaluation.md
@@ -1,3 +1,14 @@
+---
+phase: "P9 Model Tactics"
+gate: "Model uplift"
+status: "experiments must beat baseline quality metrics."
+previous:
+  - "/model-strengths"
+next:
+  - "/compare-outputs"
+  - "/switch-model"
+---
+
 # Model Evaluation
 
 Trigger: /model-evaluation
@@ -14,9 +25,3 @@ Purpose: Try a new model and compare outputs against a baseline.
 
 - Summary table and recommendations to adopt or not.
 
-## Stage alignment
-
-- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
-- **Gate**: Model uplift — experiments must beat baseline quality metrics.
-- **Previous prompts**: `/model-strengths`
-- **Next prompts**: `/compare-outputs`, `/switch-model`

--- a/model-strengths.md
+++ b/model-strengths.md
@@ -1,3 +1,15 @@
+---
+phase: "P9 Model Tactics"
+gate: "Model uplift"
+status: "capture baseline routing before experimentation."
+previous:
+  - "/feature-flags (optional)"
+  - "Stage-specific blockers"
+next:
+  - "/model-evaluation"
+  - "/compare-outputs"
+---
+
 # Model Strengths
 
 Trigger: /model-strengths
@@ -14,9 +26,3 @@ Purpose: Choose model per task type.
 
 - Routing guide with examples.
 
-## Stage alignment
-
-- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
-- **Gate**: Model uplift — capture baseline routing before experimentation.
-- **Previous prompts**: `/feature-flags` (optional) or stage-specific blockers.
-- **Next prompts**: `/model-evaluation`, `/compare-outputs`

--- a/modular-architecture.md
+++ b/modular-architecture.md
@@ -1,3 +1,14 @@
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "boundaries documented and lint/build scripts still pass; revisit during P4 Frontend UX for UI seams."
+previous:
+  - "/openapi-generate"
+next:
+  - "/db-bootstrap"
+  - "/ui-screenshots"
+  - "/design-assets"
+---
+
 # Modular Architecture
 
 Trigger: /modular-architecture
@@ -15,10 +26,3 @@ Purpose: Enforce modular boundaries and clear external interfaces.
 
 - Diagram-ready list of modules and edges, plus diffs.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts);
-  revisit during [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) for UI seams.
-- **Gate**: Test Gate lite — boundaries documented and lint/build scripts still pass.
-- **Previous prompts**: `/openapi-generate`
-- **Next prompts**: `/db-bootstrap`, `/ui-screenshots`, `/design-assets`

--- a/monitoring-setup.md
+++ b/monitoring-setup.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "observability baselines ready before rollout."
+previous:
+  - "/version-proposal"
+next:
+  - "/slo-setup"
+  - "/logging-strategy"
+---
+
 # Monitoring Setup
 
 **Trigger:** `/monitoring-setup`
@@ -16,9 +27,3 @@
 
 **Notes:** Avoid high‑cardinality labels. Sample traces selectively in prod.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Release Gate — observability baselines ready before rollout.
-- **Previous prompts**: `/version-proposal`
-- **Next prompts**: `/slo-setup`, `/logging-strategy`

--- a/openapi-generate.md
+++ b/openapi-generate.md
@@ -1,3 +1,14 @@
+---
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "generated code builds and CI checks cover the new scripts."
+previous:
+  - "/api-contract"
+next:
+  - "/modular-architecture"
+  - "/db-bootstrap"
+---
+
 # OpenAPI Generate
 
 **Trigger:** `/openapi-generate <server|client> <lang> <spec-path>`
@@ -18,9 +29,3 @@
 
 **Notes:** Prefer openapi-typescript + zod for TS clients when possible.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Test Gate lite — generated code builds and CI checks cover the new scripts.
-- **Previous prompts**: `/api-contract`
-- **Next prompts**: `/modular-architecture`, `/db-bootstrap`

--- a/owners.md
+++ b/owners.md
@@ -1,3 +1,15 @@
+---
+phase: "P7 Release & Ops"
+gate: "Review Gate"
+status: "confirm approvers and escalation paths before PR submission."
+previous:
+  - "/iac-bootstrap"
+next:
+  - "/review"
+  - "/review-branch"
+  - "/pr-desc"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Suggest likely owners/reviewers for a path.
 
 1. Gather context by inspecting `.github/CODEOWNERS` for the codeowners (if present); running `git log --pretty='- %an %ae: %s' -- {{args}} | sed -n '1,50p'` for the recent authors for the path.
@@ -17,9 +29,3 @@ Expected Output:
 
 - Likely reviewers: @frontend-team (CODEOWNERS), @jane (last 5 commits).
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Review Gate — confirm approvers and escalation paths before PR submission.
-- **Previous prompts**: `/iac-bootstrap`
-- **Next prompts**: `/review`, `/review-branch`, `/pr-desc`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prompts",
+  "private": true,
+  "scripts": {
+    "validate:metadata": "ts-node scripts/validate_metadata.ts"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/planning-process.md
+++ b/planning-process.md
@@ -1,3 +1,14 @@
+---
+phase: "P1 Plan & Scope"
+gate: "Scope Gate"
+status: "confirm problem, users, Done criteria, and stack risks are logged."
+previous:
+  - "Preflight Docs (AGENTS baseline)"
+next:
+  - "/scope-control"
+  - "/stack-evaluation"
+---
+
 # Planning Process
 
 Trigger: /planning-process
@@ -34,9 +45,3 @@ Purpose: Draft, refine, and execute a feature plan with strict scope control and
 - Planning only. No code edits.
 - Assume a Git repo with test runner available.
 
-## Stage alignment
-
-- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
-- **Gate**: Scope Gate — confirm problem, users, Done criteria, and stack risks are logged.
-- **Previous prompts**: Preflight Docs (AGENTS baseline)
-- **Next prompts**: `/scope-control`, `/stack-evaluation`

--- a/pr-desc.md
+++ b/pr-desc.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Review Gate"
+status: "PR narrative ready for approvals and release prep."
+previous:
+  - "/review-branch"
+next:
+  - "/release-notes"
+  - "/version-proposal"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Draft a PR description from the branch diff.
 
 1. Gather context by running `git diff --name-status origin/main...HEAD` for the changed files (name + status); running `git diff --shortstat origin/main...HEAD` for the high‑level stats.
@@ -18,9 +29,3 @@ Expected Output:
 
 - Actionable summary aligned with the output section.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Review Gate — PR narrative ready for approvals and release prep.
-- **Previous prompts**: `/review-branch`
-- **Next prompts**: `/release-notes`, `/version-proposal`

--- a/prototype-feature.md
+++ b/prototype-feature.md
@@ -1,3 +1,16 @@
+---
+phase:
+  - "P1 Plan & Scope"
+  - "P2 App Scaffold & Contracts"
+gate: "Prototype review"
+status: "Validate spike outcomes before committing to scope."
+previous:
+  - "/planning-process"
+next:
+  - "/scaffold-fullstack"
+  - "/api-contract"
+---
+
 # Prototype Feature
 
 Trigger: /prototype-feature
@@ -15,10 +28,3 @@ Purpose: Spin up a standalone prototype in a clean repo before merging into main
 
 - Scaffold plan and migration notes.
 
-## Stage alignment
-
-- **Phase**: Sandbox between [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope) and
-  [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Validate spike outcomes before committing to scope.
-- **Previous prompts**: `/planning-process`
-- **Next prompts**: `/scaffold-fullstack`, `/api-contract`

--- a/refactor-suggestions.md
+++ b/refactor-suggestions.md
@@ -1,3 +1,14 @@
+---
+phase: "P8 Post-release Hardening"
+gate: "Post-release cleanup"
+status: "plan high-leverage refactors once Sev-1 issues settle."
+previous:
+  - "/fix"
+next:
+  - "/file-modularity"
+  - "/dead-code-scan"
+---
+
 # Refactor Suggestions
 
 Trigger: /refactor-suggestions
@@ -14,9 +25,3 @@ Purpose: Propose repo-wide refactoring opportunities after tests exist.
 
 - Ranked list with owners and effort estimates.
 
-## Stage alignment
-
-- **Phase**: [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening)
-- **Gate**: Post-release cleanup — plan high-leverage refactors once Sev-1 issues settle.
-- **Previous prompts**: `/fix`
-- **Next prompts**: `/file-modularity`, `/dead-code-scan`

--- a/reference-implementation.md
+++ b/reference-implementation.md
@@ -1,3 +1,15 @@
+---
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "align new modules with proven patterns before deeper work."
+previous:
+  - "/scaffold-fullstack"
+  - "/api-contract"
+next:
+  - "/modular-architecture"
+  - "/openapi-generate"
+---
+
 # Reference Implementation
 
 Trigger: /reference-implementation
@@ -14,9 +26,3 @@ Purpose: Mimic the style and API of a known working example.
 
 - Side-by-side API table and patch suggestions.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Test Gate lite — align new modules with proven patterns before deeper work.
-- **Previous prompts**: `/scaffold-fullstack`, `/api-contract`
-- **Next prompts**: `/modular-architecture`, `/openapi-generate`

--- a/regression-guard.md
+++ b/regression-guard.md
@@ -1,3 +1,14 @@
+---
+phase: "P5 Quality Gates & Tests"
+gate: "Test Gate"
+status: "regression coverage in place before CI hand-off."
+previous:
+  - "/coverage-guide"
+next:
+  - "/version-control-guide"
+  - "/devops-automation"
+---
+
 # Regression Guard
 
 Trigger: /regression-guard
@@ -18,9 +29,3 @@ Purpose: Detect unrelated changes and add tests to prevent regressions.
 
 - Keep proposed tests minimal and focused.
 
-## Stage alignment
-
-- **Phase**: [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests)
-- **Gate**: Test Gate — regression coverage in place before CI hand-off.
-- **Previous prompts**: `/coverage-guide`
-- **Next prompts**: `/version-control-guide`, `/devops-automation`

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "notes compiled for staging review and production rollout."
+previous:
+  - "/pr-desc"
+next:
+  - "/version-proposal"
+  - "/monitoring-setup"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Generate human‑readable release notes from recent commits.
 
 1. Gather context by running `git log --pretty='* %s (%h) — %an' --no-merges {{args}}` for the commit log (no merges).
@@ -21,9 +32,3 @@ Expected Output:
 
 - Resolve logout crash (PR #57)
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Release Gate — notes compiled for staging review and production rollout.
-- **Previous prompts**: `/pr-desc`
-- **Next prompts**: `/version-proposal`, `/monitoring-setup`

--- a/reset-strategy.md
+++ b/reset-strategy.md
@@ -1,3 +1,13 @@
+---
+phase: "Reset Playbook"
+gate: "Clean restart"
+status: "triggered when gate criteria stall for >60 minutes."
+previous:
+  - "Any blocked stage"
+next:
+  - "Restart with /planning-process then follow the gated flow"
+---
+
 # Reset Strategy
 
 Trigger: /reset-strategy
@@ -23,9 +33,3 @@ Purpose: Decide when to hard reset and start clean to avoid layered bad diffs.
 
 - Warn about destructive nature. Require user confirmation.
 
-## Stage alignment
-
-- **Phase**: [Reset Playbook](WORKFLOW.md#reset-playbook)
-- **Gate**: Clean restart — triggered when gate criteria stall for >60 minutes.
-- **Previous prompts**: Any blocked stage
-- **Next prompts**: Restart with `/planning-process` then follow the gated flow

--- a/review-branch.md
+++ b/review-branch.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Review Gate"
+status: "branch scope validated before PR submission."
+previous:
+  - "/review"
+next:
+  - "/pr-desc"
+  - "/release-notes"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Provide a high‑level review of the current branch vs origin/main.
 
 1. Gather context by running `git diff --stat origin/main...HEAD` for the diff stats; running `git diff origin/main...HEAD | sed -n '1,200p'` for the ```diff.
@@ -17,9 +28,3 @@ Expected Output:
 
 - Structured report following the specified sections.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Review Gate — branch scope validated before PR submission.
-- **Previous prompts**: `/review`
-- **Next prompts**: `/pr-desc`, `/release-notes`

--- a/review.md
+++ b/review.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Review Gate"
+status: "peer review coverage met before merging."
+previous:
+  - "/owners"
+next:
+  - "/review-branch"
+  - "/pr-desc"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Review code matching a pattern and give actionable feedback.
 
 1. Gather context by running `rg -n {{args}} . || grep -RIn {{args}} .` for the search results for {{args}} (filename or regex).
@@ -17,9 +28,3 @@ Expected Output:
 
 - Usage cluster in src/network/* with note on inconsistent error handling.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Review Gate — peer review coverage met before merging.
-- **Previous prompts**: `/owners`
-- **Next prompts**: `/review-branch`, `/pr-desc`

--- a/scaffold-fullstack.md
+++ b/scaffold-fullstack.md
@@ -1,3 +1,15 @@
+---
+phase: "P2 App Scaffold & Contracts"
+gate: "Test Gate lite"
+status: "ensure lint/build scripts execute on the generated scaffold."
+previous:
+  - "/stack-evaluation"
+next:
+  - "/api-contract"
+  - "/openapi-generate"
+  - "/modular-architecture"
+---
+
 # Scaffold Full‑Stack App
 
 **Trigger:** `/scaffold-fullstack <stack>`
@@ -41,9 +53,3 @@
 - Assume pnpm and Node 20+. Do not run package installs automatically; propose commands instead.
 - Respect existing files; avoid overwriting without explicit confirmation.
 
-## Stage alignment
-
-- **Phase**: [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts)
-- **Gate**: Test Gate lite — ensure lint/build scripts execute on the generated scaffold.
-- **Previous prompts**: `/stack-evaluation`
-- **Next prompts**: `/api-contract`, `/openapi-generate`, `/modular-architecture`

--- a/scope-control.md
+++ b/scope-control.md
@@ -1,3 +1,14 @@
+---
+phase: "P1 Plan & Scope"
+gate: "Scope Gate"
+status: "Done criteria, scope lists, and stack choices are committed."
+previous:
+  - "/planning-process"
+next:
+  - "/stack-evaluation"
+  - "/scaffold-fullstack"
+---
+
 # Scope Control
 
 Trigger: /scope-control
@@ -23,9 +34,3 @@ Output: Move to **Ideas for later** with reason "Not needed for OAuth MVP".
 
 - Never add new scope without recording tradeoffs.
 
-## Stage alignment
-
-- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
-- **Gate**: Scope Gate — Done criteria, scope lists, and stack choices are committed.
-- **Previous prompts**: `/planning-process`
-- **Next prompts**: `/stack-evaluation`, `/scaffold-fullstack`

--- a/scripts/validate_metadata.ts
+++ b/scripts/validate_metadata.ts
@@ -1,0 +1,198 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+type Scalar = string;
+
+type MetadataValue = Scalar | Scalar[];
+
+interface Metadata {
+  phase: Scalar | Scalar[];
+  gate: Scalar;
+  status: Scalar;
+  previous: Scalar[];
+  next: Scalar[];
+  [key: string]: MetadataValue;
+}
+
+interface ParsedFrontMatter {
+  metadata: Record<string, MetadataValue>;
+  endOffset: number;
+}
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(__dirname, '..');
+  const workflowPath = path.join(repoRoot, 'WORKFLOW.md');
+  const validPhases = await loadPhases(workflowPath);
+  const markdownFiles = await collectMarkdownFiles(repoRoot);
+
+  const errors: string[] = [];
+  let validatedFiles = 0;
+
+  for (const filePath of markdownFiles) {
+    const relativePath = path.relative(repoRoot, filePath);
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = parseFrontMatter(content);
+    if (!parsed) {
+      continue;
+    }
+
+    const metadata = parsed.metadata as Partial<Metadata>;
+    validatedFiles += 1;
+
+    const phaseErrors = validatePhase(metadata.phase, validPhases, relativePath);
+    const gateErrors = validateRequiredString('gate', metadata.gate, relativePath);
+    const statusErrors = validateRequiredString('status', metadata.status, relativePath);
+    const previousErrors = validateStringArray('previous', metadata.previous, relativePath);
+    const nextErrors = validateStringArray('next', metadata.next, relativePath);
+
+    errors.push(
+      ...phaseErrors,
+      ...gateErrors,
+      ...statusErrors,
+      ...previousErrors,
+      ...nextErrors,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error('Metadata validation failed:\n');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Metadata validation passed for ${validatedFiles} file(s).`);
+}
+
+async function loadPhases(workflowPath: string): Promise<Set<string>> {
+  const content = await fs.readFile(workflowPath, 'utf8');
+  const headingRegex = /^(##|###)\s+(.+)$/gm;
+  const phases = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = headingRegex.exec(content)) !== null) {
+    phases.add(match[2].trim());
+  }
+  return phases;
+}
+
+async function collectMarkdownFiles(rootDir: string): Promise<string[]> {
+  const results: string[] = [];
+  await walk(rootDir, results);
+  return results;
+
+  async function walk(currentDir: string, acc: string[]): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) {
+        continue;
+      }
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath, acc);
+      } else if (entry.isFile() && fullPath.endsWith('.md')) {
+        acc.push(fullPath);
+      }
+    }
+  }
+}
+
+function shouldSkip(name: string): boolean {
+  return name === 'node_modules' || name === '.git' || name === '.taskmaster' || name === '.github';
+}
+
+function parseFrontMatter(content: string): ParsedFrontMatter | null {
+  if (!content.startsWith('---')) {
+    return null;
+  }
+  const closingIndex = content.indexOf('\n---', 3);
+  if (closingIndex === -1) {
+    throw new Error('Front matter missing closing delimiter.');
+  }
+  const frontMatter = content.slice(4, closingIndex);
+  const lines = frontMatter.split('\n');
+  const data: Record<string, MetadataValue> = {};
+  let currentKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (line.trim() === '') {
+      continue;
+    }
+    const itemMatch = line.match(/^[-\s]+-\s+(.*)$/);
+    if (itemMatch) {
+      if (!currentKey) {
+        throw new Error(`Array item encountered without a key in front matter: "${line}"`);
+      }
+      const array = (data[currentKey] as Scalar[]) || [];
+      array.push(parseScalar(itemMatch[1].trim()));
+      data[currentKey] = array;
+      continue;
+    }
+
+    const keyMatch = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (!keyMatch) {
+      throw new Error(`Unable to parse front matter line: "${line}"`);
+    }
+    const [, key, rawValue] = keyMatch;
+    if (rawValue.length === 0) {
+      data[key] = [];
+      currentKey = key;
+    } else {
+      data[key] = parseScalar(rawValue);
+      currentKey = null;
+    }
+  }
+
+  return { metadata: data, endOffset: closingIndex + 4 };
+}
+
+function parseScalar(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    const inner = trimmed.slice(1, -1);
+    return inner.replace(/\\"/g, '"').replace(/\\'/g, "'");
+  }
+  return trimmed;
+}
+
+function validatePhase(value: MetadataValue | undefined, validPhases: Set<string>, file: string): string[] {
+  if (value === undefined) {
+    return [`${file}: missing required field "phase".`];
+  }
+  const phases = Array.isArray(value) ? value : [value];
+  if (phases.length === 0 || phases.some((item) => typeof item !== 'string' || item.trim() === '')) {
+    return [`${file}: "phase" must contain at least one non-empty string.`];
+  }
+  const headings = Array.from(validPhases);
+  const missing = phases.filter((phase) => !headings.some((heading) => heading.includes(phase.trim())));
+  if (missing.length > 0) {
+    return [`${file}: phase value(s) not found in WORKFLOW.md headings: ${missing.join(', ')}.`];
+  }
+  return [];
+}
+
+function validateRequiredString(field: string, value: MetadataValue | undefined, file: string): string[] {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return [`${file}: missing or empty "${field}".`];
+  }
+  return [];
+}
+
+function validateStringArray(field: string, value: MetadataValue | undefined, file: string): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [`${file}: "${field}" must be a non-empty array.`];
+  }
+  const invalid = value.filter((item) => typeof item !== 'string' || item.trim() === '');
+  if (invalid.length > 0) {
+    return [`${file}: "${field}" contains empty entries.`];
+  }
+  return [];
+}
+
+main().catch((error) => {
+  console.error('Failed to validate metadata.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/secrets-manager-setup.md
+++ b/secrets-manager-setup.md
@@ -1,3 +1,14 @@
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "secret paths mapped and least-privilege policies drafted."
+previous:
+  - "/env-setup"
+next:
+  - "/iac-bootstrap"
+  - "/owners"
+---
+
 # Secrets Manager Setup
 
 **Trigger:** `/secrets-manager-setup <provider>`
@@ -16,9 +27,3 @@
 
 **Notes:** Never echo secret values. Include rotation policy.
 
-## Stage alignment
-
-- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
-- **Gate**: Review Gate — secret paths mapped and least-privilege policies drafted.
-- **Previous prompts**: `/env-setup`
-- **Next prompts**: `/iac-bootstrap`, `/owners`

--- a/slo-setup.md
+++ b/slo-setup.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "SLOs and alerts reviewed before production rollout."
+previous:
+  - "/monitoring-setup"
+next:
+  - "/logging-strategy"
+  - "/audit"
+---
+
 # SLO Setup
 
 **Trigger:** `/slo-setup`
@@ -16,9 +27,3 @@
 
 **Notes:** Tie SLOs to deploy gates and incident severity.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Release Gate — SLOs and alerts reviewed before production rollout.
-- **Previous prompts**: `/monitoring-setup`
-- **Next prompts**: `/logging-strategy`, `/audit`

--- a/stack-evaluation.md
+++ b/stack-evaluation.md
@@ -1,3 +1,14 @@
+---
+phase: "P1 Plan & Scope"
+gate: "Scope Gate"
+status: "record recommended stack and top risks before building."
+previous:
+  - "/scope-control"
+next:
+  - "/scaffold-fullstack"
+  - "/api-contract"
+---
+
 # Stack Evaluation
 
 Trigger: /stack-evaluation
@@ -14,9 +25,3 @@ Purpose: Evaluate language/framework choices relative to AI familiarity and repo
 
 - Decision memo with pros/cons and next steps.
 
-## Stage alignment
-
-- **Phase**: [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope)
-- **Gate**: Scope Gate — record recommended stack and top risks before building.
-- **Previous prompts**: `/scope-control`
-- **Next prompts**: `/scaffold-fullstack`, `/api-contract`

--- a/switch-model.md
+++ b/switch-model.md
@@ -1,3 +1,13 @@
+---
+phase: "P9 Model Tactics"
+gate: "Model uplift"
+status: "document rollback/guardrails before flipping defaults."
+previous:
+  - "/compare-outputs"
+next:
+  - "Return to the blocked stage (e.g., /integration-test) to apply learnings"
+---
+
 # Switch Model
 
 Trigger: /switch-model
@@ -15,9 +25,3 @@ Purpose: Decide when to try a different AI backend and how to compare.
 
 - Table: task → model → settings → win reason.
 
-## Stage alignment
-
-- **Phase**: [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting)
-- **Gate**: Model uplift — document rollback/guardrails before flipping defaults.
-- **Previous prompts**: `/compare-outputs`
-- **Next prompts**: Return to the blocked stage (e.g., `/integration-test`) to apply learnings.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts"]
+}

--- a/ui-screenshots.md
+++ b/ui-screenshots.md
@@ -1,3 +1,15 @@
+---
+phase: "P4 Frontend UX"
+gate: "Accessibility checks queued"
+status: "capture UX issues and backlog fixes."
+previous:
+  - "/design-assets"
+  - "/modular-architecture"
+next:
+  - "/logging-strategy"
+  - "/e2e-runner-setup"
+---
+
 # UI Screenshots
 
 Trigger: /ui-screenshots
@@ -14,9 +26,3 @@ Purpose: Analyze screenshots for UI bugs or inspiration and propose actionable U
 
 - Issue list and code snippets to fix visuals.
 
-## Stage alignment
-
-- **Phase**: [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux)
-- **Gate**: Accessibility checks queued — capture UX issues and backlog fixes.
-- **Previous prompts**: `/design-assets`, `/modular-architecture`
-- **Next prompts**: `/logging-strategy`, `/e2e-runner-setup`

--- a/version-control-guide.md
+++ b/version-control-guide.md
@@ -1,3 +1,14 @@
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "clean diff, CI green, and approvals ready."
+previous:
+  - "/regression-guard"
+next:
+  - "/devops-automation"
+  - "/env-setup"
+---
+
 # Version Control Guide
 
 Trigger: /version-control-guide
@@ -23,9 +34,3 @@ Purpose: Enforce clean incremental commits and clean-room re-implementation when
 
 - Never modify remote branches without confirmation.
 
-## Stage alignment
-
-- **Phase**: [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env)
-- **Gate**: Review Gate — clean diff, CI green, and approvals ready.
-- **Previous prompts**: `/regression-guard`
-- **Next prompts**: `/devops-automation`, `/env-setup`

--- a/version-proposal.md
+++ b/version-proposal.md
@@ -1,3 +1,14 @@
+---
+phase: "P7 Release & Ops"
+gate: "Release Gate"
+status: "version bump decision recorded before deployment."
+previous:
+  - "/release-notes"
+next:
+  - "/monitoring-setup"
+  - "/slo-setup"
+---
+
 You are a CLI assistant focused on helping contributors with the task: Propose next version (major/minor/patch) from commit history.
 
 1. Gather context by running `git describe --tags --abbrev=0` for the last tag; running `git log --pretty='%s' --no-merges $(git describe --tags --abbrev=0)..HEAD` for the commits since last tag (no merges).
@@ -17,9 +28,3 @@ Expected Output:
 
 - Structured report following the specified sections.
 
-## Stage alignment
-
-- **Phase**: [P7 Release & Ops](WORKFLOW.md#p7-release--ops)
-- **Gate**: Release Gate — version bump decision recorded before deployment.
-- **Previous prompts**: `/release-notes`
-- **Next prompts**: `/monitoring-setup`, `/slo-setup`

--- a/voice-input.md
+++ b/voice-input.md
@@ -1,3 +1,13 @@
+---
+phase: "Support"
+gate: "Support intake"
+status: "Clarify voice-derived requests before invoking gated prompts."
+previous:
+  - "Voice transcript capture"
+next:
+  - "Any stage-specific command (e.g., /planning-process)"
+---
+
 # Voice Input
 
 Trigger: /voice-input
@@ -14,10 +24,3 @@ Purpose: Support interaction from voice capture and convert to structured prompt
 
 - Cleaned command list ready to execute.
 
-## Stage alignment
-
-- **Phase**: Support — accelerates transitions between stages documented in
-  [WORKFLOW.md](WORKFLOW.md)
-- **Gate**: Clarify voice-derived requests before invoking gated prompts.
-- **Previous prompts**: Voice transcript capture
-- **Next prompts**: Any stage-specific command (e.g., `/planning-process`)


### PR DESCRIPTION
## Summary
- document the lifecycle prompt metadata schema in the docs and capture cross-cutting Support context in WORKFLOW.md
- add YAML front matter with phase, gate, status, previous, and next fields to every lifecycle prompt
- add a TypeScript metadata validator plus npm project scaffolding and contributor guidance for running it

## Testing
- npm run validate:metadata

------
https://chatgpt.com/codex/tasks/task_e_68cdafa0241c8328bda90af756927448