### PR TITLE
Add workflow metadata for commit assistant

### DIFF
--- a/commit.md
+++ b/commit.md
@@ -1,19 +1,37 @@
-You are a CLI assistant focused on helping contributors with the task: Generates a Git commit message based on staged changes.
+---
+phase: "P6 CI/CD & Env"
+gate: "Review Gate"
+status: "clean diff, CI green, and approvals ready."
+previous:
+  - "/version-control-guide"
+next:
+  - "/devops-automation"
+  - "/env-setup"
+---
 
-1. Gather context by running `git diff --staged`.
+# Commit Message Assistant
 
-2. ```diff.
-3. Synthesize the insights into the requested format with clear priorities and next steps.
+Trigger: `commit`
 
-Output:
+Purpose: Generate a conventional, review-ready commit message from the currently staged changes.
 
-- Begin with a concise summary that restates the goal: Generates a Git commit message based on staged changes.
-- Provide unified diff-style patches when recommending code changes.
-- Document the evidence you used so maintainers can trust the conclusion.
+Output: A finalized commit message with a 50–72 character imperative subject line, optional scope, and supporting body lines describing the rationale, evidence, and tests.
 
-Example Input:
-(none – command runs without arguments)
+## Steps
 
-Expected Output:
+1. Verify there is staged work with `git status --short` and stop with guidance if nothing is staged.
+2. Inspect the staged diff with `git diff --staged` and identify the primary change type (feat, fix, chore, docs, refactor, etc.) and optional scope (e.g., package or module).
+3. Draft a concise subject line in the form `<type>(<scope>): <imperative summary>` or `<type>: <imperative summary>` when no scope applies. Keep the line under 73 characters.
+4. Capture essential details in the body as wrapped bullet points or paragraphs: what changed, why it was necessary, and any follow-up actions.
+5. Document validation in a trailing section (e.g., `Tests:`) noting commands executed or why tests were skipped.
 
-- Structured report following the specified sections.
+## Example Output
+
+```
+fix(auth): prevent session expiration loop
+
+- guard refresh flow against repeated 401 responses
+- add regression coverage for expired refresh tokens
+
+Tests: npm test -- auth/session.test.ts
+```


### PR DESCRIPTION
## Summary
- add workflow metadata for the commit assistant covering the review gate stage
- replace malformed numbered list with explicit guidance for producing commit messages
- provide a concrete example of a properly formatted commit message for maintainers to reference

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdb99f11f883289d5ecf772aead42a