### PR TITLE
Standardize trigger and purpose metadata in prompts

### DIFF
--- a/api-contract.md
+++ b/api-contract.md
@@ -11,9 +11,9 @@ next:
 
 # API Contract
 
-**Trigger:** `/api-contract "<feature or domain>"`
+Trigger: /api-contract "<feature or domain>"
 
-**Purpose:** Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements.
+Purpose: Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements.
 
 **Steps:**
 

--- a/auth-scaffold.md
+++ b/auth-scaffold.md
@@ -12,9 +12,9 @@ next:
 
 # Auth Scaffold
 
-**Trigger:** `/auth-scaffold <oauth|email|oidc>`
+Trigger: /auth-scaffold <oauth|email|oidc>
 
-**Purpose:** Scaffold auth flows, routes, storage, and a basic threat model.
+Purpose: Scaffold auth flows, routes, storage, and a basic threat model.
 
 **Steps:**
 

--- a/cleanup-branches.md
+++ b/cleanup-branches.md
@@ -9,6 +9,12 @@ next:
   - "/model-strengths"
 ---
 
+# Cleanup Branches
+
+Trigger: /cleanup-branches
+
+Purpose: Recommend which local branches are safe to delete and which to keep.
+
 You are a CLI assistant focused on helping contributors with the task: Suggest safe local branch cleanup (merged/stale).
 
 1. Gather context by running `git branch --merged` for the merged into current upstream; running `git branch --no-merged` for the branches not merged; running `git for-each-ref --sort=-authordate --format='%(refname:short) — %(authordate:relative)' refs/heads` for the recently updated (last author dates).

--- a/coverage-guide.md
+++ b/coverage-guide.md
@@ -9,6 +9,12 @@ next:
   - "/version-control-guide"
 ---
 
+# Coverage Guide
+
+Trigger: /coverage-guide
+
+Purpose: Propose high-ROI tests to raise coverage using uncovered areas.
+
 You are a CLI assistant focused on helping contributors with the task: Suggest a plan to raise coverage based on uncovered areas.
 
 1. Gather context by running `find . -name 'coverage*' -type f -maxdepth 3 -print -exec head -n 40 {} \; 2>/dev/null` for the coverage hints; running `git ls-files | sed -n '1,400p'` for the repo map.

--- a/db-bootstrap.md
+++ b/db-bootstrap.md
@@ -11,9 +11,9 @@ next:
 
 # DB Bootstrap
 
-**Trigger:** `/db-bootstrap <postgres|mysql|sqlite|mongodb>`
+Trigger: /db-bootstrap <postgres|mysql|sqlite|mongodb>
 
-**Purpose:** Pick a database, initialize migrations, local compose, and seed scripts.
+Purpose: Pick a database, initialize migrations, local compose, and seed scripts.
 
 **Steps:**
 

--- a/dead-code-scan.md
+++ b/dead-code-scan.md
@@ -9,6 +9,12 @@ next:
   - "/feature-flags"
 ---
 
+# Dead Code Scan
+
+Trigger: /dead-code-scan
+
+Purpose: Identify likely dead or unused files and exports using static signals.
+
 You are a CLI assistant focused on helping contributors with the task: List likely dead or unused files and exports (static signals).
 
 1. Gather context by running `rg -n "export |module.exports|exports\.|require\(|import " -g '!node_modules' .` for the file reference graph (best‑effort).

--- a/e2e-runner-setup.md
+++ b/e2e-runner-setup.md
@@ -12,9 +12,9 @@ next:
 
 # E2E Runner Setup
 
-**Trigger:** `/e2e-runner-setup <playwright|cypress>`
+Trigger: /e2e-runner-setup <playwright|cypress>
 
-**Purpose:** Configure an end‑to‑end test runner with fixtures and data sandbox.
+Purpose: Configure an end-to-end test runner with fixtures and a data sandbox.
 
 **Steps:**
 

--- a/env-setup.md
+++ b/env-setup.md
@@ -11,9 +11,9 @@ next:
 
 # Env Setup
 
-**Trigger:** `/env-setup`
+Trigger: /env-setup
 
-**Purpose:** Create `.env.example`, runtime schema validation, and per‑env overrides.
+Purpose: Create .env.example, runtime schema validation, and per-env overrides.
 
 **Steps:**
 

--- a/feature-flags.md
+++ b/feature-flags.md
@@ -11,9 +11,9 @@ next:
 
 # Feature Flags
 
-**Trigger:** `/feature-flags <provider>`
+Trigger: /feature-flags <provider>
 
-**Purpose:** Integrate a flag provider, wire SDK, and enforce guardrails.
+Purpose: Integrate a flag provider, wire the SDK, and enforce guardrails.
 
 **Steps:**
 

--- a/fix.md
+++ b/fix.md
@@ -9,6 +9,12 @@ next:
   - "/file-modularity"
 ---
 
+# Fix
+
+Trigger: /fix "<bug summary>"
+
+Purpose: Propose a minimal, correct fix with diff-style patches.
+
 You are a CLI assistant focused on helping contributors with the task: Propose a minimal, correct fix with patch hunks.
 
 1. Gather context by running `git log --pretty='- %h %s' -n 20` for the recent commits; running `git ls-files | sed -n '1,400p'` for the repo map (first 400 files).

--- a/generate.md
+++ b/generate.md
@@ -8,6 +8,12 @@ next:
   - "/regression-guard"
 ---
 
+# Generate Unit Tests
+
+Trigger: /generate <source-file>
+
+Purpose: Generate unit tests for a given source file.
+
 You are a CLI assistant focused on helping contributors with the task: Generate unit tests for a given source file.
 
 ## Steps

--- a/iac-bootstrap.md
+++ b/iac-bootstrap.md
@@ -11,9 +11,9 @@ next:
 
 # IaC Bootstrap
 
-**Trigger:** `/iac-bootstrap <aws|gcp|azure|fly|render>`
+Trigger: /iac-bootstrap <aws|gcp|azure|fly|render>
 
-**Purpose:** Create minimal Infrastructure‑as‑Code for chosen platform plus CI pipeline hooks.
+Purpose: Create minimal Infrastructure-as-Code for the chosen platform plus CI hooks.
 
 **Steps:**
 

--- a/migration-plan.md
+++ b/migration-plan.md
@@ -11,9 +11,9 @@ next:
 
 # Migration Plan
 
-**Trigger:** `/migration-plan "<change summary>"`
+Trigger: /migration-plan "<change summary>"
 
-**Purpose:** Produce safe up/down migration steps with checks and rollback notes.
+Purpose: Produce safe up/down migration steps with checks and rollback notes.
 
 **Steps:**
 

--- a/monitoring-setup.md
+++ b/monitoring-setup.md
@@ -11,9 +11,9 @@ next:
 
 # Monitoring Setup
 
-**Trigger:** `/monitoring-setup`
+Trigger: /monitoring-setup
 
-**Purpose:** Bootstrap logs, metrics, and traces with dashboards per domain.
+Purpose: Bootstrap logs, metrics, and traces with dashboards per domain.
 
 **Steps:**
 

--- a/openapi-generate.md
+++ b/openapi-generate.md
@@ -11,9 +11,9 @@ next:
 
 # OpenAPI Generate
 
-**Trigger:** `/openapi-generate <server|client> <lang> <spec-path>`
+Trigger: /openapi-generate <server|client> <lang> <spec-path>
 
-**Purpose:** Generate server stubs or typed clients from an OpenAPI spec.
+Purpose: Generate server stubs or typed clients from an OpenAPI spec.
 
 **Steps:**
 

--- a/owners.md
+++ b/owners.md
@@ -10,6 +10,12 @@ next:
   - "/pr-desc"
 ---
 
+# Owners
+
+Trigger: /owners <path>
+
+Purpose: Suggest likely owners or reviewers for the specified path.
+
 You are a CLI assistant focused on helping contributors with the task: Suggest likely owners/reviewers for a path.
 
 1. Gather context by inspecting `.github/CODEOWNERS` for the codeowners (if present); running `git log --pretty='- %an %ae: %s' -- {{args}} | sed -n '1,50p'` for the recent authors for the path.

--- a/pr-desc.md
+++ b/pr-desc.md
@@ -9,6 +9,12 @@ next:
   - "/version-proposal"
 ---
 
+# PR Description
+
+Trigger: /pr-desc <context>
+
+Purpose: Draft a PR description from the branch diff.
+
 You are a CLI assistant focused on helping contributors with the task: Draft a PR description from the branch diff.
 
 1. Gather context by running `git diff --name-status origin/main...HEAD` for the changed files (name + status); running `git diff --shortstat origin/main...HEAD` for the high‑level stats.

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,12 @@ next:
   - "/monitoring-setup"
 ---
 
+# Release Notes
+
+Trigger: /release-notes <git-range>
+
+Purpose: Generate human-readable release notes from recent commits.
+
 You are a CLI assistant focused on helping contributors with the task: Generate human‑readable release notes from recent commits.
 
 1. Gather context by running `git log --pretty='* %s (%h) — %an' --no-merges {{args}}` for the commit log (no merges).

--- a/review-branch.md
+++ b/review-branch.md
@@ -9,6 +9,12 @@ next:
   - "/release-notes"
 ---
 
+# Review Branch
+
+Trigger: /review-branch
+
+Purpose: Provide a high-level review of the current branch versus origin/main.
+
 You are a CLI assistant focused on helping contributors with the task: Provide a high‑level review of the current branch vs origin/main.
 
 1. Gather context by running `git diff --stat origin/main...HEAD` for the diff stats; running `git diff origin/main...HEAD | sed -n '1,200p'` for the ```diff.

--- a/review.md
+++ b/review.md
@@ -9,6 +9,12 @@ next:
   - "/pr-desc"
 ---
 
+# Review
+
+Trigger: /review <pattern>
+
+Purpose: Review code matching a pattern and deliver actionable feedback.
+
 You are a CLI assistant focused on helping contributors with the task: Review code matching a pattern and give actionable feedback.
 
 1. Gather context by running `rg -n {{args}} . || grep -RIn {{args}} .` for the search results for {{args}} (filename or regex).

--- a/scaffold-fullstack.md
+++ b/scaffold-fullstack.md
@@ -12,9 +12,9 @@ next:
 
 # Scaffold Full‑Stack App
 
-**Trigger:** `/scaffold-fullstack <stack>`
+Trigger: /scaffold-fullstack <stack>
 
-**Purpose:** Create a minimal, production‑ready monorepo template with app, API, tests, CI seeds, and infra stubs.
+Purpose: Create a minimal, production-ready monorepo template with app, API, tests, CI seeds, and infra stubs.
 
 **Steps:**
 

--- a/secrets-manager-setup.md
+++ b/secrets-manager-setup.md
@@ -11,9 +11,9 @@ next:
 
 # Secrets Manager Setup
 
-**Trigger:** `/secrets-manager-setup <provider>`
+Trigger: /secrets-manager-setup <provider>
 
-**Purpose:** Provision secret store and map app variables to it.
+Purpose: Provision a secrets store and map application variables to it.
 
 **Steps:**
 

--- a/slo-setup.md
+++ b/slo-setup.md
@@ -11,9 +11,9 @@ next:
 
 # SLO Setup
 
-**Trigger:** `/slo-setup`
+Trigger: /slo-setup
 
-**Purpose:** Define Service Level Objectives, burn alerts, and runbooks.
+Purpose: Define Service Level Objectives, burn alerts, and runbooks.
 
 **Steps:**
 

--- a/version-proposal.md
+++ b/version-proposal.md
@@ -9,6 +9,12 @@ next:
   - "/slo-setup"
 ---
 
+# Version Proposal
+
+Trigger: /version-proposal
+
+Purpose: Propose the next semantic version based on commit history.
+
 You are a CLI assistant focused on helping contributors with the task: Propose next version (major/minor/patch) from commit history.
 
 1. Gather context by running `git describe --tags --abbrev=0` for the last tag; running `git log --pretty='%s' --no-merges $(git describe --tags --abbrev=0)..HEAD` for the commits since last tag (no merges).


### PR DESCRIPTION
## Summary
- add standardized `Trigger` and `Purpose` declarations to prompts missing metadata
- add H1 titles to prompts that previously opened without a heading so metadata sits beneath the title block
- align metadata formatting with the conventions used in existing prompts

## Testing
- npm run validate:metadata

------
https://chatgpt.com/codex/tasks/task_e_68cdbd3116c88328990308a6c427fbc9