### PR TITLE
feat: auto-generate catalog docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,105 +47,106 @@ Commands are grouped by development phase. Stage headings link back to
 
 | Command | What it does |
 | --- | --- |
-| /instruction-file | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` so DocFetchReport captures current guardrails. |
+| /instruction-file | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` with project-specific instructions. |
 
 ### [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope) — pass the [Scope Gate](WORKFLOW.md#scope-gate)
 
 | Command | What it does |
 | --- | --- |
-| /planning-process | Draft, refine, and execute a feature plan with strict scope control. |
-| /scope-control | Enforce explicit scope boundaries plus “won’t do” and “ideas for later” lists. |
-| /stack-evaluation | Evaluate language/framework choices relative to AI familiarity and roadmap goals. |
+| /planning-process | Draft, refine, and execute a feature plan with strict scope control and progress tracking. |
+| /scope-control | Enforce explicit scope boundaries and maintain "won't do" and "ideas for later" lists. |
+| /stack-evaluation | Evaluate language/framework choices relative to AI familiarity and repo goals. |
 
 ### [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts) — clear Test Gate lite
 
 | Command | What it does |
 | --- | --- |
-| /scaffold-fullstack | Create a minimal full-stack workspace with CI seeds. |
-| /api-contract | Author an initial OpenAPI/GraphQL contract from requirements. |
+| /api-contract | Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements. |
+| /api-docs-local | Fetch API docs and store locally for offline, deterministic reference. |
 | /openapi-generate | Generate server stubs or typed clients from an OpenAPI spec. |
-| /modular-architecture | Enforce module boundaries; revisit during P4 for UI seams. |
 | /reference-implementation | Mimic the style and API of a known working example. |
-| /api-docs-local | Fetch API docs and store locally for deterministic reference. |
+| /scaffold-fullstack | Create a minimal, production‑ready monorepo template with app, API, tests, CI seeds, and infra stubs. |
 
 ### [P3 Data & Auth](WORKFLOW.md#p3-data--auth) — migrations must dry-run cleanly
 
 | Command | What it does |
 | --- | --- |
-| /db-bootstrap | Pick a database, initialize migrations, and seed scripts. |
-| /migration-plan | Produce safe up/down migration steps with rollback notes. |
-| /auth-scaffold | Scaffold auth flows, threat model, and secure session storage. |
+| /auth-scaffold | Scaffold auth flows, routes, storage, and a basic threat model. |
+| /db-bootstrap | Pick a database, initialize migrations, local compose, and seed scripts. |
+| /migration-plan | Produce safe up/down migration steps with checks and rollback notes. |
 
 ### [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) — queue accessibility checks
 
 | Command | What it does |
 | --- | --- |
-| /design-assets | Generate favicons and lightweight visual assets from your product brand. |
-| /ui-screenshots | Analyze screenshots for UI bugs or inspiration and propose actionable fixes. |
+| /design-assets | Generate favicons and small design snippets from product brand. |
+| /ui-screenshots | Analyze screenshots for UI bugs or inspiration and propose actionable UI changes. |
 
 ### [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests) — meet the [Test Gate](WORKFLOW.md#test-gate)
 
 | Command | What it does |
 | --- | --- |
-| /e2e-runner-setup | Configure Playwright/Cypress with fixtures and CI jobs. |
-| /integration-test | Generate end-to-end tests that simulate real user flows. |
 | /coverage-guide | Suggest a plan to raise coverage based on uncovered areas. |
+| /e2e-runner-setup | Configure an end‑to‑end test runner with fixtures and data sandbox. |
+| /generate | Generate unit tests for a given source file. |
+| /integration-test | Generate E2E tests that simulate real user flows. |
 | /regression-guard | Detect unrelated changes and add tests to prevent regressions. |
 
 ### [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env) — satisfy the [Review Gate](WORKFLOW.md#review-gate)
 
 | Command | What it does |
 | --- | --- |
-| /version-control-guide | Enforce clean incremental commits and clean-room re-implementation before merge. |
-| /devops-automation | Configure servers, DNS, SSL, and CI/CD with pragmatic defaults. |
-| /env-setup | Create `.env.example`, runtime validation, and per-environment overrides. |
-| /secrets-manager-setup | Provision a secret store and map application variables. |
-| /iac-bootstrap | Create minimal IaC stacks with plan/apply pipelines. |
+| /commit | Generate a conventional, review-ready commit message from the currently staged changes. |
+| /devops-automation | Configure servers, DNS, SSL, CI/CD at a pragmatic level. |
+| /env-setup | Create `.env.example`, runtime schema validation, and per‑env overrides. |
+| /iac-bootstrap | Create minimal Infrastructure‑as‑Code for chosen platform plus CI pipeline hooks. |
+| /secrets-manager-setup | Provision secret store and map app variables to it. |
+| /version-control-guide | Enforce clean incremental commits and clean-room re-implementation when finalizing. |
 
 ### [P7 Release & Ops](WORKFLOW.md#p7-release--ops) — clear the [Release Gate](WORKFLOW.md#release-gate)
 
 | Command | What it does |
 | --- | --- |
-| /owners | Suggest owners and reviewers for a path using CODEOWNERS and history. |
-| /review | Review code matching a pattern and provide actionable feedback. |
-| /review-branch | Provide a high-level review of the branch compared to `origin/main`. |
-| /pr-desc | Draft a PR description from the branch diff. |
-| /release-notes | Convert recent commits into human-readable release notes. |
-| /version-proposal | Propose the next semantic version based on commit history. |
+| /audit | Audit repository hygiene and suggest improvements. |
+| /explain-code | Provide line-by-line explanations for a given file or diff. |
 | /monitoring-setup | Bootstrap logs, metrics, and traces with dashboards per domain. |
-| /slo-setup | Define SLOs, burn alerts, and supporting runbooks. |
-| /logging-strategy | Add or remove diagnostic logging with structured levels and privacy considerations. |
+| /owners | Suggest likely owners/reviewers for a path. |
+| /pr-desc | Draft a PR description from the branch diff. |
+| /release-notes | Generate human‑readable release notes from recent commits. |
+| /review | Review code matching a pattern and give actionable feedback. |
+| /review-branch | Provide a high‑level review of the current branch vs origin/main. |
+| /slo-setup | Define Service Level Objectives, burn alerts, and runbooks. |
+| /version-proposal | Propose next version (major/minor/patch) from commit history. |
 
 ### [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening) — resolve Sev-1 issues
 
 | Command | What it does |
 | --- | --- |
+| /cleanup-branches | Suggest safe local branch cleanup (merged/stale). |
+| /dead-code-scan | List likely dead or unused files and exports (static signals). |
 | /error-analysis | Analyze error logs and enumerate likely root causes with fixes. |
-| /fix | Propose a minimal, correct fix with patch hunks. |
-| /refactor-suggestions | Propose repo-wide refactoring opportunities once tests exist. |
-| /file-modularity | Enforce smaller files and propose safe splits for giant files. |
-| /dead-code-scan | Flag likely dead files and exports using static signals. |
-| /cleanup-branches | Recommend local branches that are merged or stale and safe to delete. |
 | /feature-flags | Integrate a flag provider, wire SDK, and enforce guardrails. |
+| /file-modularity | Enforce smaller files and propose safe splits for giant files. |
+| /fix | Propose a minimal, correct fix with patch hunks. |
+| /refactor-suggestions | Propose repo-wide refactoring opportunities after tests exist. |
 
 ### [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting) — document uplift before switching defaults
 
 | Command | What it does |
 | --- | --- |
-| /model-strengths | Route work by model strengths for faster delegation. |
+| /compare-outputs | Run multiple models or tools on the same prompt and summarize best output. |
 | /model-evaluation | Try a new model and compare outputs against a baseline. |
-| /compare-outputs | Run multiple models or tools on the same prompt and summarize the best output. |
+| /model-strengths | Choose model per task type. |
 | /switch-model | Decide when to try a different AI backend and how to compare. |
 
 ### [Reset Playbook](WORKFLOW.md#reset-playbook) and other cross-cutting helpers
 
 | Command | Stage tie-in | What it does |
 | --- | --- | --- |
-| /reset-strategy | Reset path | Decide when to hard reset and start clean to avoid layered bad diffs. |
-| /prototype-feature | P1–P2 sandbox | Spin up a standalone prototype before merging into main. |
-| /content-generation | Support | Draft docs, blog posts, or marketing copy aligned with the codebase. |
-| /explain-code | Support | Provide line-by-line explanations for a given file or diff. |
-| /voice-input | Support | Convert speech to structured prompts for Codex. |
+| /content-generation | 11) Evidence Log | Draft docs, blog posts, or marketing copy aligned with the codebase. |
+| /prototype-feature | P1 Plan & Scope, P2 App Scaffold & Contracts | Spin up a standalone prototype in a clean repo before merging into main. |
+| /reset-strategy | Reset Playbook | Decide when to hard reset and start clean to avoid layered bad diffs. |
+| /voice-input | Support | Support interaction from voice capture and convert to structured prompts. |
 
 ## Reference assets
 

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,0 +1,1011 @@
+{
+  "generatedAt": "2025-09-19T20:38:57.556Z",
+  "entries": [
+    {
+      "slug": "api-contract",
+      "path": "api-contract.md",
+      "title": "API Contract",
+      "command": "/api-contract",
+      "trigger": "`/api-contract \"<feature or domain>\"`",
+      "purpose": "Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements.",
+      "phases": [
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Test Gate lite",
+      "status": "contract checked into repo with sample generation running cleanly.",
+      "previous": [
+        "/scaffold-fullstack"
+      ],
+      "next": [
+        "/openapi-generate",
+        "/modular-architecture"
+      ]
+    },
+    {
+      "slug": "api-docs-local",
+      "path": "api-docs-local.md",
+      "title": "API Docs Local",
+      "command": "/api-docs-local",
+      "trigger": "/api-docs-local",
+      "purpose": "Fetch API docs and store locally for offline, deterministic reference.",
+      "phases": [
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Test Gate lite",
+      "status": "contracts cached locally for repeatable generation.",
+      "previous": [
+        "/scaffold-fullstack"
+      ],
+      "next": [
+        "/api-contract",
+        "/openapi-generate"
+      ]
+    },
+    {
+      "slug": "audit",
+      "path": "audit.md",
+      "title": "Audit",
+      "command": "/audit",
+      "trigger": "/audit",
+      "purpose": "Audit repository hygiene and suggest improvements.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Release Gate",
+      "status": "readiness criteria before shipping.",
+      "previous": [
+        "/logging-strategy"
+      ],
+      "next": [
+        "/error-analysis",
+        "/fix"
+      ]
+    },
+    {
+      "slug": "auth-scaffold",
+      "path": "auth-scaffold.md",
+      "title": "Auth Scaffold",
+      "command": "/auth-scaffold",
+      "trigger": "`/auth-scaffold <oauth|email|oidc>`",
+      "purpose": "Scaffold auth flows, routes, storage, and a basic threat model.",
+      "phases": [
+        "P3 Data & Auth"
+      ],
+      "gate": "Migration dry-run",
+      "status": "auth flows threat-modeled and test accounts wired.",
+      "previous": [
+        "/migration-plan"
+      ],
+      "next": [
+        "/modular-architecture",
+        "/ui-screenshots",
+        "/e2e-runner-setup"
+      ]
+    },
+    {
+      "slug": "cleanup-branches",
+      "path": "cleanup-branches.md",
+      "title": "Cleanup Branches",
+      "command": "/cleanup-branches",
+      "trigger": "/cleanup-branches",
+      "purpose": "Suggest safe local branch cleanup (merged/stale).",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "repo tidy with stale branches archived.",
+      "previous": [
+        "/dead-code-scan"
+      ],
+      "next": [
+        "/feature-flags",
+        "/model-strengths"
+      ]
+    },
+    {
+      "slug": "commit",
+      "path": "commit.md",
+      "title": "Commit Message Assistant",
+      "command": "/commit",
+      "trigger": "commit",
+      "purpose": "Generate a conventional, review-ready commit message from the currently staged changes.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "clean diff, CI green, and approvals ready.",
+      "previous": [
+        "/version-control-guide"
+      ],
+      "next": [
+        "/devops-automation",
+        "/env-setup"
+      ]
+    },
+    {
+      "slug": "compare-outputs",
+      "path": "compare-outputs.md",
+      "title": "Compare Outputs",
+      "command": "/compare-outputs",
+      "trigger": "/compare-outputs",
+      "purpose": "Run multiple models or tools on the same prompt and summarize best output.",
+      "phases": [
+        "P9 Model Tactics"
+      ],
+      "gate": "Model uplift",
+      "status": "comparative data compiled before switching defaults.",
+      "previous": [
+        "/model-evaluation"
+      ],
+      "next": [
+        "/switch-model"
+      ]
+    },
+    {
+      "slug": "content-generation",
+      "path": "content-generation.md",
+      "title": "Content Generation",
+      "command": "/content-generation",
+      "trigger": "/content-generation",
+      "purpose": "Draft docs, blog posts, or marketing copy aligned with the codebase.",
+      "phases": [
+        "11) Evidence Log"
+      ],
+      "gate": "Evidence Log",
+      "status": "Ensure docs stay synced with current phase deliverables.",
+      "previous": [
+        "Stage-specific work just completed"
+      ],
+      "next": [
+        "/release-notes",
+        "/summary (if sharing updates)"
+      ]
+    },
+    {
+      "slug": "coverage-guide",
+      "path": "coverage-guide.md",
+      "title": "Coverage Guide",
+      "command": "/coverage-guide",
+      "trigger": "/coverage-guide",
+      "purpose": "Suggest a plan to raise coverage based on uncovered areas.",
+      "phases": [
+        "P5 Quality Gates & Tests"
+      ],
+      "gate": "Test Gate",
+      "status": "coverage targets and regression guard plan recorded.",
+      "previous": [
+        "/integration-test"
+      ],
+      "next": [
+        "/regression-guard",
+        "/version-control-guide"
+      ]
+    },
+    {
+      "slug": "db-bootstrap",
+      "path": "db-bootstrap.md",
+      "title": "DB Bootstrap",
+      "command": "/db-bootstrap",
+      "trigger": "`/db-bootstrap <postgres|mysql|sqlite|mongodb>`",
+      "purpose": "Pick a database, initialize migrations, local compose, and seed scripts.",
+      "phases": [
+        "P3 Data & Auth"
+      ],
+      "gate": "Migration dry-run",
+      "status": "migrations apply/rollback cleanly with seeds populated.",
+      "previous": [
+        "/modular-architecture"
+      ],
+      "next": [
+        "/migration-plan",
+        "/auth-scaffold"
+      ]
+    },
+    {
+      "slug": "dead-code-scan",
+      "path": "dead-code-scan.md",
+      "title": "Dead Code Scan",
+      "command": "/dead-code-scan",
+      "trigger": "/dead-code-scan",
+      "purpose": "List likely dead or unused files and exports (static signals).",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "ensure code removals keep prod stable.",
+      "previous": [
+        "/file-modularity"
+      ],
+      "next": [
+        "/cleanup-branches",
+        "/feature-flags"
+      ]
+    },
+    {
+      "slug": "design-assets",
+      "path": "design-assets.md",
+      "title": "Design Assets",
+      "command": "/design-assets",
+      "trigger": "/design-assets",
+      "purpose": "Generate favicons and small design snippets from product brand.",
+      "phases": [
+        "P4 Frontend UX"
+      ],
+      "gate": "Accessibility checks queued",
+      "status": "ensure assets support design review.",
+      "previous": [
+        "/modular-architecture"
+      ],
+      "next": [
+        "/ui-screenshots",
+        "/logging-strategy"
+      ]
+    },
+    {
+      "slug": "devops-automation",
+      "path": "devops-automation.md",
+      "title": "DevOps Automation",
+      "command": "/devops-automation",
+      "trigger": "/devops-automation",
+      "purpose": "Configure servers, DNS, SSL, CI/CD at a pragmatic level.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "CI pipeline codified, rollback steps rehearsed.",
+      "previous": [
+        "/version-control-guide"
+      ],
+      "next": [
+        "/env-setup",
+        "/secrets-manager-setup",
+        "/iac-bootstrap"
+      ]
+    },
+    {
+      "slug": "e2e-runner-setup",
+      "path": "e2e-runner-setup.md",
+      "title": "E2E Runner Setup",
+      "command": "/e2e-runner-setup",
+      "trigger": "`/e2e-runner-setup <playwright|cypress>`",
+      "purpose": "Configure an end‑to‑end test runner with fixtures and data sandbox.",
+      "phases": [
+        "P5 Quality Gates & Tests"
+      ],
+      "gate": "Test Gate",
+      "status": "runner green locally and wired into CI before expanding coverage.",
+      "previous": [
+        "/auth-scaffold",
+        "/ui-screenshots"
+      ],
+      "next": [
+        "/integration-test",
+        "/coverage-guide"
+      ]
+    },
+    {
+      "slug": "env-setup",
+      "path": "env-setup.md",
+      "title": "Env Setup",
+      "command": "/env-setup",
+      "trigger": "`/env-setup`",
+      "purpose": "Create `.env.example`, runtime schema validation, and per‑env overrides.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "environment schemas enforced and CI respects strict loading.",
+      "previous": [
+        "/devops-automation"
+      ],
+      "next": [
+        "/secrets-manager-setup",
+        "/iac-bootstrap"
+      ]
+    },
+    {
+      "slug": "error-analysis",
+      "path": "error-analysis.md",
+      "title": "Error Analysis",
+      "command": "/error-analysis",
+      "trigger": "/error-analysis",
+      "purpose": "Analyze error logs and enumerate likely root causes with fixes.",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "Sev-1 incidents triaged with fixes scheduled.",
+      "previous": [
+        "/logging-strategy",
+        "/audit"
+      ],
+      "next": [
+        "/fix",
+        "/refactor-suggestions"
+      ]
+    },
+    {
+      "slug": "explain-code",
+      "path": "explain-code.md",
+      "title": "Explain Code",
+      "command": "/explain-code",
+      "trigger": "/explain-code",
+      "purpose": "Provide line-by-line explanations for a given file or diff.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Review Gate",
+      "status": "Improve reviewer comprehension before approvals.",
+      "previous": [
+        "/owners",
+        "/review"
+      ],
+      "next": [
+        "/review-branch",
+        "/pr-desc"
+      ]
+    },
+    {
+      "slug": "feature-flags",
+      "path": "feature-flags.md",
+      "title": "Feature Flags",
+      "command": "/feature-flags",
+      "trigger": "`/feature-flags <provider>`",
+      "purpose": "Integrate a flag provider, wire SDK, and enforce guardrails.",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "guardrails added before toggling new flows.",
+      "previous": [
+        "/cleanup-branches"
+      ],
+      "next": [
+        "/model-strengths",
+        "/model-evaluation"
+      ]
+    },
+    {
+      "slug": "file-modularity",
+      "path": "file-modularity.md",
+      "title": "File Modularity",
+      "command": "/file-modularity",
+      "trigger": "/file-modularity",
+      "purpose": "Enforce smaller files and propose safe splits for giant files.",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "structure debt addressed without destabilizing prod.",
+      "previous": [
+        "/refactor-suggestions"
+      ],
+      "next": [
+        "/dead-code-scan",
+        "/cleanup-branches"
+      ]
+    },
+    {
+      "slug": "fix",
+      "path": "fix.md",
+      "title": "Fix",
+      "command": "/fix",
+      "trigger": "/fix",
+      "purpose": "Propose a minimal, correct fix with patch hunks.",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "validated fix with regression coverage before closing incident.",
+      "previous": [
+        "/error-analysis"
+      ],
+      "next": [
+        "/refactor-suggestions",
+        "/file-modularity"
+      ]
+    },
+    {
+      "slug": "generate",
+      "path": "generate.md",
+      "title": "Generate",
+      "command": "/generate",
+      "trigger": "/generate",
+      "purpose": "Generate unit tests for a given source file.",
+      "phases": [
+        "P5 Quality Gates & Tests"
+      ],
+      "gate": "Test Gate",
+      "status": "targeted unit tests authored for the specified module.",
+      "previous": [
+        "/coverage-guide"
+      ],
+      "next": [
+        "/regression-guard"
+      ]
+    },
+    {
+      "slug": "iac-bootstrap",
+      "path": "iac-bootstrap.md",
+      "title": "IaC Bootstrap",
+      "command": "/iac-bootstrap",
+      "trigger": "`/iac-bootstrap <aws|gcp|azure|fly|render>`",
+      "purpose": "Create minimal Infrastructure‑as‑Code for chosen platform plus CI pipeline hooks.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "IaC applied in staging with drift detection configured.",
+      "previous": [
+        "/secrets-manager-setup"
+      ],
+      "next": [
+        "/owners",
+        "/review"
+      ]
+    },
+    {
+      "slug": "instruction-file",
+      "path": "instruction-file.md",
+      "title": "Instruction File",
+      "command": "/instruction-file",
+      "trigger": "/instruction-file",
+      "purpose": "Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` with project-specific instructions.",
+      "phases": [
+        "P0 Preflight Docs"
+      ],
+      "gate": "DocFetchReport",
+      "status": "capture approved instructions before proceeding.",
+      "previous": [
+        "Preflight discovery (AGENTS baseline)"
+      ],
+      "next": [
+        "/planning-process",
+        "/scope-control"
+      ]
+    },
+    {
+      "slug": "integration-test",
+      "path": "integration-test.md",
+      "title": "Integration Test",
+      "command": "/integration-test",
+      "trigger": "/integration-test",
+      "purpose": "Generate E2E tests that simulate real user flows.",
+      "phases": [
+        "P5 Quality Gates & Tests"
+      ],
+      "gate": "Test Gate",
+      "status": "happy path E2E must pass locally and in CI.",
+      "previous": [
+        "/e2e-runner-setup"
+      ],
+      "next": [
+        "/coverage-guide",
+        "/regression-guard"
+      ]
+    },
+    {
+      "slug": "migration-plan",
+      "path": "migration-plan.md",
+      "title": "Migration Plan",
+      "command": "/migration-plan",
+      "trigger": "`/migration-plan \"<change summary>\"`",
+      "purpose": "Produce safe up/down migration steps with checks and rollback notes.",
+      "phases": [
+        "P3 Data & Auth"
+      ],
+      "gate": "Migration dry-run",
+      "status": "validated rollback steps and safety checks documented.",
+      "previous": [
+        "/db-bootstrap"
+      ],
+      "next": [
+        "/auth-scaffold",
+        "/e2e-runner-setup"
+      ]
+    },
+    {
+      "slug": "model-evaluation",
+      "path": "model-evaluation.md",
+      "title": "Model Evaluation",
+      "command": "/model-evaluation",
+      "trigger": "/model-evaluation",
+      "purpose": "Try a new model and compare outputs against a baseline.",
+      "phases": [
+        "P9 Model Tactics"
+      ],
+      "gate": "Model uplift",
+      "status": "experiments must beat baseline quality metrics.",
+      "previous": [
+        "/model-strengths"
+      ],
+      "next": [
+        "/compare-outputs",
+        "/switch-model"
+      ]
+    },
+    {
+      "slug": "model-strengths",
+      "path": "model-strengths.md",
+      "title": "Model Strengths",
+      "command": "/model-strengths",
+      "trigger": "/model-strengths",
+      "purpose": "Choose model per task type.",
+      "phases": [
+        "P9 Model Tactics"
+      ],
+      "gate": "Model uplift",
+      "status": "capture baseline routing before experimentation.",
+      "previous": [
+        "/feature-flags (optional)",
+        "Stage-specific blockers"
+      ],
+      "next": [
+        "/model-evaluation",
+        "/compare-outputs"
+      ]
+    },
+    {
+      "slug": "monitoring-setup",
+      "path": "monitoring-setup.md",
+      "title": "Monitoring Setup",
+      "command": "/monitoring-setup",
+      "trigger": "`/monitoring-setup`",
+      "purpose": "Bootstrap logs, metrics, and traces with dashboards per domain.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Release Gate",
+      "status": "observability baselines ready before rollout.",
+      "previous": [
+        "/version-proposal"
+      ],
+      "next": [
+        "/slo-setup",
+        "/logging-strategy"
+      ]
+    },
+    {
+      "slug": "openapi-generate",
+      "path": "openapi-generate.md",
+      "title": "OpenAPI Generate",
+      "command": "/openapi-generate",
+      "trigger": "`/openapi-generate <server|client> <lang> <spec-path>`",
+      "purpose": "Generate server stubs or typed clients from an OpenAPI spec.",
+      "phases": [
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Test Gate lite",
+      "status": "generated code builds and CI checks cover the new scripts.",
+      "previous": [
+        "/api-contract"
+      ],
+      "next": [
+        "/modular-architecture",
+        "/db-bootstrap"
+      ]
+    },
+    {
+      "slug": "owners",
+      "path": "owners.md",
+      "title": "Owners",
+      "command": "/owners",
+      "trigger": "/owners",
+      "purpose": "Suggest likely owners/reviewers for a path.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Review Gate",
+      "status": "confirm approvers and escalation paths before PR submission.",
+      "previous": [
+        "/iac-bootstrap"
+      ],
+      "next": [
+        "/review",
+        "/review-branch",
+        "/pr-desc"
+      ]
+    },
+    {
+      "slug": "planning-process",
+      "path": "planning-process.md",
+      "title": "Planning Process",
+      "command": "/planning-process",
+      "trigger": "/planning-process",
+      "purpose": "Draft, refine, and execute a feature plan with strict scope control and progress tracking.",
+      "phases": [
+        "P1 Plan & Scope"
+      ],
+      "gate": "Scope Gate",
+      "status": "confirm problem, users, Done criteria, and stack risks are logged.",
+      "previous": [
+        "Preflight Docs (AGENTS baseline)"
+      ],
+      "next": [
+        "/scope-control",
+        "/stack-evaluation"
+      ]
+    },
+    {
+      "slug": "pr-desc",
+      "path": "pr-desc.md",
+      "title": "Pr Desc",
+      "command": "/pr-desc",
+      "trigger": "/pr-desc",
+      "purpose": "Draft a PR description from the branch diff.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Review Gate",
+      "status": "PR narrative ready for approvals and release prep.",
+      "previous": [
+        "/review-branch"
+      ],
+      "next": [
+        "/release-notes",
+        "/version-proposal"
+      ]
+    },
+    {
+      "slug": "prototype-feature",
+      "path": "prototype-feature.md",
+      "title": "Prototype Feature",
+      "command": "/prototype-feature",
+      "trigger": "/prototype-feature",
+      "purpose": "Spin up a standalone prototype in a clean repo before merging into main.",
+      "phases": [
+        "P1 Plan & Scope",
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Prototype review",
+      "status": "Validate spike outcomes before committing to scope.",
+      "previous": [
+        "/planning-process"
+      ],
+      "next": [
+        "/scaffold-fullstack",
+        "/api-contract"
+      ]
+    },
+    {
+      "slug": "refactor-suggestions",
+      "path": "refactor-suggestions.md",
+      "title": "Refactor Suggestions",
+      "command": "/refactor-suggestions",
+      "trigger": "/refactor-suggestions",
+      "purpose": "Propose repo-wide refactoring opportunities after tests exist.",
+      "phases": [
+        "P8 Post-release Hardening"
+      ],
+      "gate": "Post-release cleanup",
+      "status": "plan high-leverage refactors once Sev-1 issues settle.",
+      "previous": [
+        "/fix"
+      ],
+      "next": [
+        "/file-modularity",
+        "/dead-code-scan"
+      ]
+    },
+    {
+      "slug": "reference-implementation",
+      "path": "reference-implementation.md",
+      "title": "Reference Implementation",
+      "command": "/reference-implementation",
+      "trigger": "/reference-implementation",
+      "purpose": "Mimic the style and API of a known working example.",
+      "phases": [
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Test Gate lite",
+      "status": "align new modules with proven patterns before deeper work.",
+      "previous": [
+        "/scaffold-fullstack",
+        "/api-contract"
+      ],
+      "next": [
+        "/modular-architecture",
+        "/openapi-generate"
+      ]
+    },
+    {
+      "slug": "regression-guard",
+      "path": "regression-guard.md",
+      "title": "Regression Guard",
+      "command": "/regression-guard",
+      "trigger": "/regression-guard",
+      "purpose": "Detect unrelated changes and add tests to prevent regressions.",
+      "phases": [
+        "P5 Quality Gates & Tests"
+      ],
+      "gate": "Test Gate",
+      "status": "regression coverage in place before CI hand-off.",
+      "previous": [
+        "/coverage-guide"
+      ],
+      "next": [
+        "/version-control-guide",
+        "/devops-automation"
+      ]
+    },
+    {
+      "slug": "release-notes",
+      "path": "release-notes.md",
+      "title": "Release Notes",
+      "command": "/release-notes",
+      "trigger": "/release-notes",
+      "purpose": "Generate human‑readable release notes from recent commits.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Release Gate",
+      "status": "notes compiled for staging review and production rollout.",
+      "previous": [
+        "/pr-desc"
+      ],
+      "next": [
+        "/version-proposal",
+        "/monitoring-setup"
+      ]
+    },
+    {
+      "slug": "reset-strategy",
+      "path": "reset-strategy.md",
+      "title": "Reset Strategy",
+      "command": "/reset-strategy",
+      "trigger": "/reset-strategy",
+      "purpose": "Decide when to hard reset and start clean to avoid layered bad diffs.",
+      "phases": [
+        "Reset Playbook"
+      ],
+      "gate": "Clean restart",
+      "status": "triggered when gate criteria stall for >60 minutes.",
+      "previous": [
+        "Any blocked stage"
+      ],
+      "next": [
+        "Restart with /planning-process then follow the gated flow"
+      ]
+    },
+    {
+      "slug": "review",
+      "path": "review.md",
+      "title": "Review",
+      "command": "/review",
+      "trigger": "/review",
+      "purpose": "Review code matching a pattern and give actionable feedback.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Review Gate",
+      "status": "peer review coverage met before merging.",
+      "previous": [
+        "/owners"
+      ],
+      "next": [
+        "/review-branch",
+        "/pr-desc"
+      ]
+    },
+    {
+      "slug": "review-branch",
+      "path": "review-branch.md",
+      "title": "Review Branch",
+      "command": "/review-branch",
+      "trigger": "/review-branch",
+      "purpose": "Provide a high‑level review of the current branch vs origin/main.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Review Gate",
+      "status": "branch scope validated before PR submission.",
+      "previous": [
+        "/review"
+      ],
+      "next": [
+        "/pr-desc",
+        "/release-notes"
+      ]
+    },
+    {
+      "slug": "scaffold-fullstack",
+      "path": "scaffold-fullstack.md",
+      "title": "Scaffold Full‑Stack App",
+      "command": "/scaffold-fullstack",
+      "trigger": "`/scaffold-fullstack <stack>`",
+      "purpose": "Create a minimal, production‑ready monorepo template with app, API, tests, CI seeds, and infra stubs.",
+      "phases": [
+        "P2 App Scaffold & Contracts"
+      ],
+      "gate": "Test Gate lite",
+      "status": "ensure lint/build scripts execute on the generated scaffold.",
+      "previous": [
+        "/stack-evaluation"
+      ],
+      "next": [
+        "/api-contract",
+        "/openapi-generate",
+        "/modular-architecture"
+      ]
+    },
+    {
+      "slug": "scope-control",
+      "path": "scope-control.md",
+      "title": "Scope Control",
+      "command": "/scope-control",
+      "trigger": "/scope-control",
+      "purpose": "Enforce explicit scope boundaries and maintain \"won't do\" and \"ideas for later\" lists.",
+      "phases": [
+        "P1 Plan & Scope"
+      ],
+      "gate": "Scope Gate",
+      "status": "Done criteria, scope lists, and stack choices are committed.",
+      "previous": [
+        "/planning-process"
+      ],
+      "next": [
+        "/stack-evaluation",
+        "/scaffold-fullstack"
+      ]
+    },
+    {
+      "slug": "secrets-manager-setup",
+      "path": "secrets-manager-setup.md",
+      "title": "Secrets Manager Setup",
+      "command": "/secrets-manager-setup",
+      "trigger": "`/secrets-manager-setup <provider>`",
+      "purpose": "Provision secret store and map app variables to it.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "secret paths mapped and least-privilege policies drafted.",
+      "previous": [
+        "/env-setup"
+      ],
+      "next": [
+        "/iac-bootstrap",
+        "/owners"
+      ]
+    },
+    {
+      "slug": "slo-setup",
+      "path": "slo-setup.md",
+      "title": "SLO Setup",
+      "command": "/slo-setup",
+      "trigger": "`/slo-setup`",
+      "purpose": "Define Service Level Objectives, burn alerts, and runbooks.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Release Gate",
+      "status": "SLOs and alerts reviewed before production rollout.",
+      "previous": [
+        "/monitoring-setup"
+      ],
+      "next": [
+        "/logging-strategy",
+        "/audit"
+      ]
+    },
+    {
+      "slug": "stack-evaluation",
+      "path": "stack-evaluation.md",
+      "title": "Stack Evaluation",
+      "command": "/stack-evaluation",
+      "trigger": "/stack-evaluation",
+      "purpose": "Evaluate language/framework choices relative to AI familiarity and repo goals.",
+      "phases": [
+        "P1 Plan & Scope"
+      ],
+      "gate": "Scope Gate",
+      "status": "record recommended stack and top risks before building.",
+      "previous": [
+        "/scope-control"
+      ],
+      "next": [
+        "/scaffold-fullstack",
+        "/api-contract"
+      ]
+    },
+    {
+      "slug": "switch-model",
+      "path": "switch-model.md",
+      "title": "Switch Model",
+      "command": "/switch-model",
+      "trigger": "/switch-model",
+      "purpose": "Decide when to try a different AI backend and how to compare.",
+      "phases": [
+        "P9 Model Tactics"
+      ],
+      "gate": "Model uplift",
+      "status": "document rollback/guardrails before flipping defaults.",
+      "previous": [
+        "/compare-outputs"
+      ],
+      "next": [
+        "Return to the blocked stage (e.g., /integration-test) to apply learnings"
+      ]
+    },
+    {
+      "slug": "ui-screenshots",
+      "path": "ui-screenshots.md",
+      "title": "UI Screenshots",
+      "command": "/ui-screenshots",
+      "trigger": "/ui-screenshots",
+      "purpose": "Analyze screenshots for UI bugs or inspiration and propose actionable UI changes.",
+      "phases": [
+        "P4 Frontend UX"
+      ],
+      "gate": "Accessibility checks queued",
+      "status": "capture UX issues and backlog fixes.",
+      "previous": [
+        "/design-assets",
+        "/modular-architecture"
+      ],
+      "next": [
+        "/logging-strategy",
+        "/e2e-runner-setup"
+      ]
+    },
+    {
+      "slug": "version-control-guide",
+      "path": "version-control-guide.md",
+      "title": "Version Control Guide",
+      "command": "/version-control-guide",
+      "trigger": "/version-control-guide",
+      "purpose": "Enforce clean incremental commits and clean-room re-implementation when finalizing.",
+      "phases": [
+        "P6 CI/CD & Env"
+      ],
+      "gate": "Review Gate",
+      "status": "clean diff, CI green, and approvals ready.",
+      "previous": [
+        "/regression-guard"
+      ],
+      "next": [
+        "/devops-automation",
+        "/env-setup"
+      ]
+    },
+    {
+      "slug": "version-proposal",
+      "path": "version-proposal.md",
+      "title": "Version Proposal",
+      "command": "/version-proposal",
+      "trigger": "/version-proposal",
+      "purpose": "Propose next version (major/minor/patch) from commit history.",
+      "phases": [
+        "P7 Release & Ops"
+      ],
+      "gate": "Release Gate",
+      "status": "version bump decision recorded before deployment.",
+      "previous": [
+        "/release-notes"
+      ],
+      "next": [
+        "/monitoring-setup",
+        "/slo-setup"
+      ]
+    },
+    {
+      "slug": "voice-input",
+      "path": "voice-input.md",
+      "title": "Voice Input",
+      "command": "/voice-input",
+      "trigger": "/voice-input",
+      "purpose": "Support interaction from voice capture and convert to structured prompts.",
+      "phases": [
+        "Support"
+      ],
+      "gate": "Support intake",
+      "status": "Clarify voice-derived requests before invoking gated prompts.",
+      "previous": [
+        "Voice transcript capture"
+      ],
+      "next": [
+        "Any stage-specific command (e.g., /planning-process)"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "prompts",
   "private": true,
   "scripts": {
-    "validate:metadata": "ts-node scripts/validate_metadata.ts"
+    "validate:metadata": "ts-node scripts/validate_metadata.ts",
+    "build:catalog": "ts-node scripts/build_catalog.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/scripts/build_catalog.ts
+++ b/scripts/build_catalog.ts
@@ -1,0 +1,288 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { generateDocs } from './generate_docs';
+
+type Scalar = string;
+
+type MetadataValue = Scalar | Scalar[];
+
+interface ParsedFrontMatter {
+  metadata: Record<string, MetadataValue>;
+  endOffset: number;
+}
+
+interface CatalogEntry {
+  slug: string;
+  path: string;
+  title: string;
+  command: string;
+  trigger: string;
+  purpose: string;
+  phases: string[];
+  gate: string;
+  status: string;
+  previous: string[];
+  next: string[];
+}
+
+interface CatalogOutput {
+  generatedAt: string;
+  entries: CatalogEntry[];
+}
+
+async function main(): Promise<void> {
+  const repoRoot = path.resolve(__dirname, '..');
+  const args = new Set(process.argv.slice(2));
+  const updateWorkflow = args.has('--update-workflow');
+
+  const markdownFiles = await collectMarkdownFiles(repoRoot);
+  const entries: CatalogEntry[] = [];
+
+  for (const filePath of markdownFiles) {
+    const relativePath = path.relative(repoRoot, filePath);
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = parseFrontMatter(content);
+    if (!parsed) {
+      continue;
+    }
+
+    try {
+      const { metadata, endOffset } = parsed;
+      const phases = normalizeStringArray(metadata.phase, 'phase', relativePath);
+      const gate = ensureString(metadata.gate, 'gate', relativePath);
+      const status = ensureString(metadata.status, 'status', relativePath);
+      const previous = normalizeStringArray(metadata.previous, 'previous', relativePath);
+      const next = normalizeStringArray(metadata.next, 'next', relativePath);
+
+      const body = content.slice(endOffset).trimStart();
+      const slug = path.basename(relativePath, path.extname(relativePath));
+      const title = extractTitle(body) ?? formatTitleFromSlug(slug);
+      const trigger = extractTrigger(body) ?? `/${slug}`;
+      const command = resolveCommand(trigger, slug);
+      const purpose = derivePurpose(body, slug);
+
+      entries.push({
+        slug,
+        path: relativePath,
+        title,
+        command,
+        trigger,
+        purpose,
+        phases,
+        gate,
+        status,
+        previous,
+        next,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[build_catalog] Skipping ${relativePath}: ${message}`);
+    }
+  }
+
+  if (entries.length === 0) {
+    throw new Error('No catalog entries were discovered.');
+  }
+
+  entries.sort((a, b) => a.command.localeCompare(b.command));
+
+  const catalog: CatalogOutput = {
+    generatedAt: new Date().toISOString(),
+    entries,
+  };
+
+  const catalogPath = path.join(repoRoot, 'docs', 'catalog.json');
+  await writeJsonAtomic(catalogPath, catalog);
+
+  await generateDocs(catalog, { repoRoot, updateWorkflow });
+}
+
+async function collectMarkdownFiles(rootDir: string): Promise<string[]> {
+  const results: string[] = [];
+
+  await walk(rootDir);
+  return results;
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (shouldSkip(entry.name)) {
+        continue;
+      }
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+  }
+}
+
+function shouldSkip(name: string): boolean {
+  return name === 'node_modules' || name === '.git' || name === '.taskmaster' || name === '.github';
+}
+
+function parseFrontMatter(content: string): ParsedFrontMatter | null {
+  if (!content.startsWith('---')) {
+    return null;
+  }
+  const closingIndex = content.indexOf('\n---', 3);
+  if (closingIndex === -1) {
+    throw new Error('Front matter missing closing delimiter.');
+  }
+  const frontMatter = content.slice(4, closingIndex);
+  const lines = frontMatter.split('\n');
+  const data: Record<string, MetadataValue> = {};
+  let currentKey: string | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (line.trim() === '') {
+      continue;
+    }
+
+    const itemMatch = line.match(/^[-\s]+-\s+(.*)$/);
+    if (itemMatch) {
+      if (!currentKey) {
+        throw new Error(`Array item encountered without a key in front matter: "${line}"`);
+      }
+      const array = (data[currentKey] as Scalar[]) || [];
+      array.push(parseScalar(itemMatch[1].trim()));
+      data[currentKey] = array;
+      continue;
+    }
+
+    const keyMatch = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (!keyMatch) {
+      throw new Error(`Unable to parse front matter line: "${line}"`);
+    }
+    const [, key, rawValue] = keyMatch;
+    if (rawValue.length === 0) {
+      data[key] = [];
+      currentKey = key;
+    } else {
+      data[key] = parseScalar(rawValue);
+      currentKey = null;
+    }
+  }
+
+  return { metadata: data, endOffset: closingIndex + 4 };
+}
+
+function parseScalar(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    const inner = trimmed.slice(1, -1);
+    return inner.replace(/\\"/g, '"').replace(/\\'/g, "'");
+  }
+  return trimmed;
+}
+
+function normalizeStringArray(value: MetadataValue | undefined, field: string, file: string): string[] {
+  if (value === undefined) {
+    throw new Error(`${file}: missing required field "${field}".`);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      throw new Error(`${file}: "${field}" must contain at least one entry.`);
+    }
+    return value.map((item) => ensureNonEmptyString(item, field, file));
+  }
+  return [ensureNonEmptyString(value, field, file)];
+}
+
+function ensureString(value: MetadataValue | undefined, field: string, file: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${file}: missing or empty "${field}".`);
+  }
+  return value.trim();
+}
+
+function ensureNonEmptyString(value: MetadataValue, field: string, file: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${file}: "${field}" entries must be non-empty strings.`);
+  }
+  return value.trim();
+}
+
+function extractTitle(body: string): string | null {
+  const headingMatch = body.match(/^#\s+(.+)$/m);
+  return headingMatch ? headingMatch[1].trim() : null;
+}
+
+function extractTrigger(body: string): string | null {
+  const triggerMatch = body.match(/^\s*(?:\*\*)?Trigger(?:\*\*)?:\s*(.+)$/mi);
+  return triggerMatch ? cleanupInline(triggerMatch[1]) : null;
+}
+
+function resolveCommand(trigger: string, slug: string): string {
+  const commandMatch = trigger.match(/\/[a-z0-9-]+/i);
+  if (commandMatch) {
+    return commandMatch[0];
+  }
+  return `/${slug}`;
+}
+
+function derivePurpose(body: string, slug: string): string {
+  const purposeMatch = body.match(/^\s*(?:\*\*)?Purpose(?:\*\*)?:\s*(.+)$/mi);
+  if (purposeMatch) {
+    return cleanupInline(purposeMatch[1]);
+  }
+
+  const lines = body.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) {
+      continue;
+    }
+    if (/^\s*(?:\*\*)?Trigger/.test(line)) {
+      continue;
+    }
+    const personaMatch = line.match(/You are a CLI assistant[^:]*:\s*(.+)/i);
+    if (personaMatch) {
+      return personaMatch[1].trim();
+    }
+    return line;
+  }
+
+  return `Prompt for ${slug.replace(/-/g, ' ')}`;
+}
+
+function cleanupInline(value: string): string {
+  let result = value.trim();
+  if (result.startsWith('`') && result.endsWith('`')) {
+    result = result.slice(1, -1).trim();
+  }
+  if (result.startsWith('**')) {
+    result = result.slice(2).trimStart();
+  }
+  if (result.endsWith('**')) {
+    result = result.slice(0, -2).trimEnd();
+  }
+  return result;
+}
+
+async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tempPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.${Date.now()}`);
+  const payload = `${JSON.stringify(data, null, 2)}\n`;
+  await fs.writeFile(tempPath, payload, 'utf8');
+  await fs.rename(tempPath, filePath);
+}
+
+function formatTitleFromSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+main().catch((error) => {
+  console.error('Failed to build catalog.');
+  console.error(error);
+  process.exitCode = 1;
+});
+
+export type { CatalogEntry, CatalogOutput };

--- a/scripts/generate_docs.ts
+++ b/scripts/generate_docs.ts
@@ -1,0 +1,173 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { CatalogEntry, CatalogOutput } from './build_catalog';
+
+interface GenerateDocsOptions {
+  repoRoot: string;
+  updateWorkflow: boolean;
+}
+
+interface PhaseGrouping {
+  [phase: string]: CatalogEntry[];
+}
+
+export async function generateDocs(
+  catalog: CatalogOutput,
+  options: GenerateDocsOptions,
+): Promise<void> {
+  const { repoRoot, updateWorkflow } = options;
+  await updateReadme(catalog.entries, repoRoot);
+
+  if (updateWorkflow) {
+    await updateWorkflowDiagram(catalog.entries, repoRoot);
+  }
+}
+
+async function updateReadme(entries: CatalogEntry[], repoRoot: string): Promise<void> {
+  const readmePath = path.join(repoRoot, 'README.md');
+  const original = await fs.readFile(readmePath, 'utf8');
+  const lines = original.split(/\r?\n/);
+
+  const { numberedPhaseMap, crossCutting } = groupEntries(entries);
+  const updatedLines = [...lines];
+
+  for (let i = 0; i < updatedLines.length; i += 1) {
+    const line = updatedLines[i];
+    const headingMatch = line.match(/^### \[([^\]]+)\]/);
+    if (!headingMatch) {
+      continue;
+    }
+    const headingLabel = headingMatch[1];
+    if (headingLabel.startsWith('P') && numberedPhaseMap[headingLabel]) {
+      const tableLines = buildPhaseTable(numberedPhaseMap[headingLabel]);
+      replaceTableBlock(updatedLines, i + 1, tableLines);
+    } else if (headingLabel === 'Reset Playbook') {
+      const tableLines = buildCrossCuttingTable(crossCutting);
+      replaceTableBlock(updatedLines, i + 1, tableLines);
+    }
+  }
+
+  const updatedContent = `${updatedLines.join('\n')}`;
+  if (updatedContent !== original) {
+    await writeFileAtomic(readmePath, updatedContent);
+  }
+}
+
+function groupEntries(entries: CatalogEntry[]): {
+  numberedPhaseMap: PhaseGrouping;
+  crossCutting: CatalogEntry[];
+} {
+  const numberedPhaseMap: PhaseGrouping = {};
+  const crossCutting: CatalogEntry[] = [];
+
+  for (const entry of entries) {
+    const numericPhases = entry.phases.filter((phase) => /^P\d+\b/.test(phase));
+    if (entry.phases.length === 1 && numericPhases.length === 1) {
+      const phase = numericPhases[0];
+      if (!numberedPhaseMap[phase]) {
+        numberedPhaseMap[phase] = [];
+      }
+      numberedPhaseMap[phase].push(entry);
+    } else {
+      crossCutting.push(entry);
+    }
+  }
+
+  for (const phase of Object.keys(numberedPhaseMap)) {
+    numberedPhaseMap[phase].sort((a, b) => a.command.localeCompare(b.command));
+  }
+  crossCutting.sort((a, b) => a.command.localeCompare(b.command));
+
+  return { numberedPhaseMap, crossCutting };
+}
+
+function buildPhaseTable(entries: CatalogEntry[]): string[] {
+  const rows = ['| Command | What it does |', '| --- | --- |'];
+  for (const entry of entries) {
+    rows.push(`| ${entry.command} | ${entry.purpose} |`);
+  }
+  if (entries.length === 0) {
+    rows.push('| _No commands yet_ | |');
+  }
+  return rows;
+}
+
+function buildCrossCuttingTable(entries: CatalogEntry[]): string[] {
+  const rows = ['| Command | Stage tie-in | What it does |', '| --- | --- | --- |'];
+  for (const entry of entries) {
+    const stage = entry.phases.join(', ');
+    rows.push(`| ${entry.command} | ${stage} | ${entry.purpose} |`);
+  }
+  if (entries.length === 0) {
+    rows.push('| _No commands yet_ | — | |');
+  }
+  return rows;
+}
+
+function replaceTableBlock(lines: string[], startIndex: number, newTable: string[]): void {
+  let index = startIndex;
+  while (index < lines.length && lines[index].trim() === '') {
+    index += 1;
+  }
+
+  const tableStart = index;
+  while (index < lines.length && lines[index].trim().startsWith('|')) {
+    index += 1;
+  }
+  const tableEnd = index;
+
+  lines.splice(tableStart, tableEnd - tableStart, ...newTable);
+}
+
+async function updateWorkflowDiagram(entries: CatalogEntry[], repoRoot: string): Promise<void> {
+  const workflowPath = path.join(repoRoot, 'workflow.mmd');
+  const nodeIds = new Map<string, string>();
+  const edges: Array<[string, string]> = [];
+
+  for (const entry of entries) {
+    const id = sanitizeId(entry.command);
+    nodeIds.set(entry.command, id);
+  }
+
+  for (const entry of entries) {
+    const sourceId = nodeIds.get(entry.command);
+    if (!sourceId) {
+      continue;
+    }
+    for (const target of entry.next) {
+      const commandMatch = target.match(/\/[a-z0-9-]+/i);
+      if (!commandMatch) {
+        continue;
+      }
+      const targetCommand = commandMatch[0];
+      const targetId = nodeIds.get(targetCommand);
+      if (!targetId) {
+        continue;
+      }
+      edges.push([sourceId, targetId]);
+    }
+  }
+
+  const lines = ['flowchart TD', '  %% Auto-generated from catalog metadata'];
+  for (const [command, id] of nodeIds.entries()) {
+    lines.push(`  ${id}["${command}"]`);
+  }
+  for (const [from, to] of edges) {
+    lines.push(`  ${from} --> ${to}`);
+  }
+
+  lines.push('');
+  await writeFileAtomic(workflowPath, `${lines.join('\n')}`);
+}
+
+function sanitizeId(command: string): string {
+  return command.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tempPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.${Date.now()}`);
+  await fs.writeFile(tempPath, content, 'utf8');
+  await fs.rename(tempPath, filePath);
+}


### PR DESCRIPTION
## Summary
- add a build_catalog.ts script that collects prompt metadata into docs/catalog.json and orchestrates doc generation
- implement generate_docs.ts to refresh README tables from the catalog and optionally rebuild workflow.mmd behind a flag
- refresh README phase tables using catalog data to keep commands and descriptions in sync

## Testing
- npm run build:catalog
- npm run validate:metadata

------
https://chatgpt.com/codex/tasks/task_e_68cdbd35151c8328ae877c8f02719f01