### PR TITLE
docs: outline catalog maintenance workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,9 @@ Thanks for helping extend the prompt catalog. Follow these guidelines so metadat
 
 1. Install dev dependencies once: `npm install`.
 2. Run the metadata check before adding or editing prompts: `npm run validate:metadata`.
-3. Fix any reported issues before opening a PR.
+3. Regenerate the catalog artifacts every time you touch a prompt: `npm run build:catalog`.
+4. Fix any reported issues before opening a PR.
+
+`npm run build:catalog` rewrites `catalog.json` and the README tables so downstream tooling and the MCP roadmap work on tool exposure and state tracking have accurate metadata. Our pre-commit hook and CI guard run these commands and will fail if generated files are stale, so make sure to include the refreshed artifacts in your commit.
 
 The validator ensures front matter stays in sync with the workflow gates and stops regressions early.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This pack extends the default Codex CLI prompts with vibe-coding playbooks inspi
 1. Clone or copy this repository into `~/.codex/prompts`. The CLI hot-reloads changes, but restarting Codex guarantees the new commands are registered.
 2. Optionally commit the directory into your dotfiles so the prompts travel with your workstation setup.
 
+## Contributor workflow
+
+Run these commands whenever you add or edit prompts so the generated catalog stays in sync:
+
+1. `npm install` — install the TypeScript tooling used by the validation scripts.
+2. `npm run validate:metadata` — confirm every prompt’s front matter matches the lifecycle workflow.
+3. `npm run build:catalog` — regenerate `catalog.json` and refresh the README tables.
+
+`npm run build:catalog` must run after each prompt change; it keeps our published metadata accurate for the upcoming [MCP roadmap](#future-enhancements) work on tool exposure and state tracking. The pre-commit hook and CI guard execute these checks and will fail when `catalog.json` or the README tables are stale, so expect local or remote failures if the command is skipped.
+
 ## Using these prompts
 
 - **Direct slash commands**: Invoke the files that declare a `Trigger:` (table below) straight from Codex. Example: `/planning-process Add OAuth login` opens `planning-process.md` and walks through the feature plan template.


### PR DESCRIPTION
## Summary
- document the required npm commands for maintaining the prompt catalog
- explain how the build:catalog step regenerates generated assets and supports the MCP roadmap
- update the contributing guide to note the pre-commit/CI guard on generated artifacts

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68cdbd3c45e88328a3d9a535d1b8c6d1