### PR TITLE
feat: automate README tables from catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,105 +57,107 @@ Commands are grouped by development phase. Stage headings link back to
 
 | Command | What it does |
 | --- | --- |
-| /instruction-file | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` so DocFetchReport captures current guardrails. |
+| /instruction-file | Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` with project-specific instructions. |
 
 ### [P1 Plan & Scope](WORKFLOW.md#p1-plan--scope) — pass the [Scope Gate](WORKFLOW.md#scope-gate)
 
 | Command | What it does |
 | --- | --- |
-| /planning-process | Draft, refine, and execute a feature plan with strict scope control. |
-| /scope-control | Enforce explicit scope boundaries plus “won’t do” and “ideas for later” lists. |
-| /stack-evaluation | Evaluate language/framework choices relative to AI familiarity and roadmap goals. |
+| /planning-process | Draft, refine, and execute a feature plan with strict scope control and progress tracking. |
+| /prototype-feature | Spin up a standalone prototype in a clean repo before merging into main. |
+| /scope-control | Enforce explicit scope boundaries and maintain "won't do" and "ideas for later" lists. |
+| /stack-evaluation | Evaluate language/framework choices relative to AI familiarity and repo goals. |
 
 ### [P2 App Scaffold & Contracts](WORKFLOW.md#p2-app-scaffold--contracts) — clear Test Gate lite
 
 | Command | What it does |
 | --- | --- |
-| /scaffold-fullstack | Create a minimal full-stack workspace with CI seeds. |
-| /api-contract | Author an initial OpenAPI/GraphQL contract from requirements. |
-| /openapi-generate | Generate server stubs or typed clients from an OpenAPI spec. |
-| /modular-architecture | Enforce module boundaries; revisit during P4 for UI seams. |
+| /api-contract "<feature or domain>" | Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements. |
+| /api-docs-local | Fetch API docs and store locally for offline, deterministic reference. |
+| /openapi-generate <server\|client> <lang> <spec-path> | Generate server stubs or typed clients from an OpenAPI spec. |
+| /prototype-feature | Spin up a standalone prototype in a clean repo before merging into main. |
 | /reference-implementation | Mimic the style and API of a known working example. |
-| /api-docs-local | Fetch API docs and store locally for deterministic reference. |
+| /scaffold-fullstack <stack> | Create a minimal, production-ready monorepo template with app, API, tests, CI seeds, and infra stubs. |
 
 ### [P3 Data & Auth](WORKFLOW.md#p3-data--auth) — migrations must dry-run cleanly
 
 | Command | What it does |
 | --- | --- |
-| /db-bootstrap | Pick a database, initialize migrations, and seed scripts. |
-| /migration-plan | Produce safe up/down migration steps with rollback notes. |
-| /auth-scaffold | Scaffold auth flows, threat model, and secure session storage. |
+| /auth-scaffold <oauth\|email\|oidc> | Scaffold auth flows, routes, storage, and a basic threat model. |
+| /db-bootstrap <postgres\|mysql\|sqlite\|mongodb> | Pick a database, initialize migrations, local compose, and seed scripts. |
+| /migration-plan "<change summary>" | Produce safe up/down migration steps with checks and rollback notes. |
 
 ### [P4 Frontend UX](WORKFLOW.md#p4-frontend-ux) — queue accessibility checks
 
 | Command | What it does |
 | --- | --- |
-| /design-assets | Generate favicons and lightweight visual assets from your product brand. |
-| /ui-screenshots | Analyze screenshots for UI bugs or inspiration and propose actionable fixes. |
+| /design-assets | Generate favicons and small design snippets from product brand. |
+| /ui-screenshots | Analyze screenshots for UI bugs or inspiration and propose actionable UI changes. |
 
 ### [P5 Quality Gates & Tests](WORKFLOW.md#p5-quality-gates--tests) — meet the [Test Gate](WORKFLOW.md#test-gate)
 
 | Command | What it does |
 | --- | --- |
-| /e2e-runner-setup | Configure Playwright/Cypress with fixtures and CI jobs. |
-| /integration-test | Generate end-to-end tests that simulate real user flows. |
-| /coverage-guide | Suggest a plan to raise coverage based on uncovered areas. |
+| /coverage-guide | Propose high-ROI tests to raise coverage using uncovered areas. |
+| /e2e-runner-setup <playwright\|cypress> | Configure an end-to-end test runner with fixtures and a data sandbox. |
+| /generate <source-file> | Generate unit tests for a given source file. |
+| /integration-test | Generate E2E tests that simulate real user flows. |
 | /regression-guard | Detect unrelated changes and add tests to prevent regressions. |
 
 ### [P6 CI/CD & Env](WORKFLOW.md#p6-cicd--env) — satisfy the [Review Gate](WORKFLOW.md#review-gate)
 
 | Command | What it does |
 | --- | --- |
-| /version-control-guide | Enforce clean incremental commits and clean-room re-implementation before merge. |
-| /devops-automation | Configure servers, DNS, SSL, and CI/CD with pragmatic defaults. |
-| /env-setup | Create `.env.example`, runtime validation, and per-environment overrides. |
-| /secrets-manager-setup | Provision a secret store and map application variables. |
-| /iac-bootstrap | Create minimal IaC stacks with plan/apply pipelines. |
+| /devops-automation | Configure servers, DNS, SSL, CI/CD at a pragmatic level. |
+| /env-setup | Create .env.example, runtime schema validation, and per-env overrides. |
+| /iac-bootstrap <aws\|gcp\|azure\|fly\|render> | Create minimal Infrastructure-as-Code for the chosen platform plus CI hooks. |
+| /secrets-manager-setup <provider> | Provision a secrets store and map application variables to it. |
+| /version-control-guide | Enforce clean incremental commits and clean-room re-implementation when finalizing. |
+| commit | Generate a conventional, review-ready commit message from the currently staged changes. |
 
 ### [P7 Release & Ops](WORKFLOW.md#p7-release--ops) — clear the [Release Gate](WORKFLOW.md#release-gate)
 
 | Command | What it does |
 | --- | --- |
-| /owners | Suggest owners and reviewers for a path using CODEOWNERS and history. |
-| /review | Review code matching a pattern and provide actionable feedback. |
-| /review-branch | Provide a high-level review of the branch compared to `origin/main`. |
-| /pr-desc | Draft a PR description from the branch diff. |
-| /release-notes | Convert recent commits into human-readable release notes. |
-| /version-proposal | Propose the next semantic version based on commit history. |
+| /audit | Audit repository hygiene and suggest improvements. |
+| /explain-code | Provide line-by-line explanations for a given file or diff. |
 | /monitoring-setup | Bootstrap logs, metrics, and traces with dashboards per domain. |
-| /slo-setup | Define SLOs, burn alerts, and supporting runbooks. |
-| /logging-strategy | Add or remove diagnostic logging with structured levels and privacy considerations. |
+| /owners <path> | Suggest likely owners or reviewers for the specified path. |
+| /pr-desc <context> | Draft a PR description from the branch diff. |
+| /release-notes <git-range> | Generate human-readable release notes from recent commits. |
+| /review <pattern> | Review code matching a pattern and deliver actionable feedback. |
+| /review-branch | Provide a high-level review of the current branch versus origin/main. |
+| /slo-setup | Define Service Level Objectives, burn alerts, and runbooks. |
+| /version-proposal | Propose the next semantic version based on commit history. |
 
 ### [P8 Post-release Hardening](WORKFLOW.md#p8-post-release-hardening) — resolve Sev-1 issues
 
 | Command | What it does |
 | --- | --- |
+| /cleanup-branches | Recommend which local branches are safe to delete and which to keep. |
+| /dead-code-scan | Identify likely dead or unused files and exports using static signals. |
 | /error-analysis | Analyze error logs and enumerate likely root causes with fixes. |
-| /fix | Propose a minimal, correct fix with patch hunks. |
-| /refactor-suggestions | Propose repo-wide refactoring opportunities once tests exist. |
+| /feature-flags <provider> | Integrate a flag provider, wire the SDK, and enforce guardrails. |
 | /file-modularity | Enforce smaller files and propose safe splits for giant files. |
-| /dead-code-scan | Flag likely dead files and exports using static signals. |
-| /cleanup-branches | Recommend local branches that are merged or stale and safe to delete. |
-| /feature-flags | Integrate a flag provider, wire SDK, and enforce guardrails. |
+| /fix "<bug summary>" | Propose a minimal, correct fix with diff-style patches. |
+| /refactor-suggestions | Propose repo-wide refactoring opportunities after tests exist. |
 
 ### [P9 Model Tactics](WORKFLOW.md#p9-model-tactics-cross-cutting) — document uplift before switching defaults
 
 | Command | What it does |
 | --- | --- |
-| /model-strengths | Route work by model strengths for faster delegation. |
+| /compare-outputs | Run multiple models or tools on the same prompt and summarize best output. |
 | /model-evaluation | Try a new model and compare outputs against a baseline. |
-| /compare-outputs | Run multiple models or tools on the same prompt and summarize the best output. |
+| /model-strengths | Choose model per task type. |
 | /switch-model | Decide when to try a different AI backend and how to compare. |
 
 ### [Reset Playbook](WORKFLOW.md#reset-playbook) and other cross-cutting helpers
 
 | Command | Stage tie-in | What it does |
 | --- | --- | --- |
-| /reset-strategy | Reset path | Decide when to hard reset and start clean to avoid layered bad diffs. |
-| /prototype-feature | P1–P2 sandbox | Spin up a standalone prototype before merging into main. |
-| /content-generation | Support | Draft docs, blog posts, or marketing copy aligned with the codebase. |
-| /explain-code | Support | Provide line-by-line explanations for a given file or diff. |
-| /voice-input | Support | Convert speech to structured prompts for Codex. |
+| /content-generation | 11) Evidence Log | Draft docs, blog posts, or marketing copy aligned with the codebase. |
+| /reset-strategy | Reset Playbook | Decide when to hard reset and start clean to avoid layered bad diffs. |
+| /voice-input | Support | Support interaction from voice capture and convert to structured prompts. |
 
 ## Reference assets
 

--- a/catalog.json
+++ b/catalog.json
@@ -187,7 +187,7 @@
       "phase": "P2 App Scaffold & Contracts",
       "command": "/scaffold-fullstack <stack>",
       "title": "Scaffold Full‑Stack App",
-      "purpose": "Create a minimal, production‑ready monorepo template with app, API, tests, CI seeds, and infra stubs.",
+      "purpose": "Create a minimal, production-ready monorepo template with app, API, tests, CI seeds, and infra stubs.",
       "gate": "Test Gate lite",
       "status": "ensure lint/build scripts execute on the generated scaffold.",
       "previous": [
@@ -292,7 +292,7 @@
       "phase": "P5 Quality Gates & Tests",
       "command": "/coverage-guide",
       "title": "Coverage Guide",
-      "purpose": "",
+      "purpose": "Propose high-ROI tests to raise coverage using uncovered areas.",
       "gate": "Test Gate",
       "status": "coverage targets and regression guard plan recorded.",
       "previous": [
@@ -308,7 +308,7 @@
       "phase": "P5 Quality Gates & Tests",
       "command": "/e2e-runner-setup <playwright|cypress>",
       "title": "E2E Runner Setup",
-      "purpose": "Configure an end‑to‑end test runner with fixtures and data sandbox.",
+      "purpose": "Configure an end-to-end test runner with fixtures and a data sandbox.",
       "gate": "Test Gate",
       "status": "runner green locally and wired into CI before expanding coverage.",
       "previous": [
@@ -323,9 +323,9 @@
     },
     {
       "phase": "P5 Quality Gates & Tests",
-      "command": "/generate",
-      "title": "Generate",
-      "purpose": "",
+      "command": "/generate <source-file>",
+      "title": "Generate Unit Tests",
+      "purpose": "Generate unit tests for a given source file.",
       "gate": "Test Gate",
       "status": "targeted unit tests authored for the specified module.",
       "previous": [
@@ -391,7 +391,7 @@
       "phase": "P6 CI/CD & Env",
       "command": "/env-setup",
       "title": "Env Setup",
-      "purpose": "Create `.env.example`, runtime schema validation, and per‑env overrides.",
+      "purpose": "Create .env.example, runtime schema validation, and per-env overrides.",
       "gate": "Review Gate",
       "status": "environment schemas enforced and CI respects strict loading.",
       "previous": [
@@ -407,7 +407,7 @@
       "phase": "P6 CI/CD & Env",
       "command": "/iac-bootstrap <aws|gcp|azure|fly|render>",
       "title": "IaC Bootstrap",
-      "purpose": "Create minimal Infrastructure‑as‑Code for chosen platform plus CI pipeline hooks.",
+      "purpose": "Create minimal Infrastructure-as-Code for the chosen platform plus CI hooks.",
       "gate": "Review Gate",
       "status": "IaC applied in staging with drift detection configured.",
       "previous": [
@@ -423,7 +423,7 @@
       "phase": "P6 CI/CD & Env",
       "command": "/secrets-manager-setup <provider>",
       "title": "Secrets Manager Setup",
-      "purpose": "Provision secret store and map app variables to it.",
+      "purpose": "Provision a secrets store and map application variables to it.",
       "gate": "Review Gate",
       "status": "secret paths mapped and least-privilege policies drafted.",
       "previous": [
@@ -520,9 +520,9 @@
     },
     {
       "phase": "P7 Release & Ops",
-      "command": "/owners",
+      "command": "/owners <path>",
       "title": "Owners",
-      "purpose": "",
+      "purpose": "Suggest likely owners or reviewers for the specified path.",
       "gate": "Review Gate",
       "status": "confirm approvers and escalation paths before PR submission.",
       "previous": [
@@ -537,9 +537,9 @@
     },
     {
       "phase": "P7 Release & Ops",
-      "command": "/pr-desc",
-      "title": "Pr Desc",
-      "purpose": "",
+      "command": "/pr-desc <context>",
+      "title": "PR Description",
+      "purpose": "Draft a PR description from the branch diff.",
       "gate": "Review Gate",
       "status": "PR narrative ready for approvals and release prep.",
       "previous": [
@@ -553,9 +553,9 @@
     },
     {
       "phase": "P7 Release & Ops",
-      "command": "/release-notes",
+      "command": "/release-notes <git-range>",
       "title": "Release Notes",
-      "purpose": "",
+      "purpose": "Generate human-readable release notes from recent commits.",
       "gate": "Release Gate",
       "status": "notes compiled for staging review and production rollout.",
       "previous": [
@@ -569,9 +569,9 @@
     },
     {
       "phase": "P7 Release & Ops",
-      "command": "/review",
+      "command": "/review <pattern>",
       "title": "Review",
-      "purpose": "",
+      "purpose": "Review code matching a pattern and deliver actionable feedback.",
       "gate": "Review Gate",
       "status": "peer review coverage met before merging.",
       "previous": [
@@ -587,7 +587,7 @@
       "phase": "P7 Release & Ops",
       "command": "/review-branch",
       "title": "Review Branch",
-      "purpose": "",
+      "purpose": "Provide a high-level review of the current branch versus origin/main.",
       "gate": "Review Gate",
       "status": "branch scope validated before PR submission.",
       "previous": [
@@ -619,7 +619,7 @@
       "phase": "P7 Release & Ops",
       "command": "/version-proposal",
       "title": "Version Proposal",
-      "purpose": "",
+      "purpose": "Propose the next semantic version based on commit history.",
       "gate": "Release Gate",
       "status": "version bump decision recorded before deployment.",
       "previous": [
@@ -637,7 +637,7 @@
       "phase": "P8 Post-release Hardening",
       "command": "/cleanup-branches",
       "title": "Cleanup Branches",
-      "purpose": "",
+      "purpose": "Recommend which local branches are safe to delete and which to keep.",
       "gate": "Post-release cleanup",
       "status": "repo tidy with stale branches archived.",
       "previous": [
@@ -653,7 +653,7 @@
       "phase": "P8 Post-release Hardening",
       "command": "/dead-code-scan",
       "title": "Dead Code Scan",
-      "purpose": "",
+      "purpose": "Identify likely dead or unused files and exports using static signals.",
       "gate": "Post-release cleanup",
       "status": "ensure code removals keep prod stable.",
       "previous": [
@@ -686,7 +686,7 @@
       "phase": "P8 Post-release Hardening",
       "command": "/feature-flags <provider>",
       "title": "Feature Flags",
-      "purpose": "Integrate a flag provider, wire SDK, and enforce guardrails.",
+      "purpose": "Integrate a flag provider, wire the SDK, and enforce guardrails.",
       "gate": "Post-release cleanup",
       "status": "guardrails added before toggling new flows.",
       "previous": [
@@ -716,9 +716,9 @@
     },
     {
       "phase": "P8 Post-release Hardening",
-      "command": "/fix",
+      "command": "/fix \"<bug summary>\"",
       "title": "Fix",
-      "purpose": "",
+      "purpose": "Propose a minimal, correct fix with diff-style patches.",
       "gate": "Post-release cleanup",
       "status": "validated fix with regression coverage before closing incident.",
       "previous": [

--- a/scripts/catalog_types.ts
+++ b/scripts/catalog_types.ts
@@ -1,0 +1,22 @@
+export interface PromptCatalogEntry {
+  phase: string;
+  command: string;
+  title: string;
+  purpose: string;
+  gate: string;
+  status: string;
+  previous: string[];
+  next: string[];
+  path: string;
+}
+
+export type PromptCatalog = Record<string, PromptCatalogEntry[]>;
+
+export function normalizePhaseLabel(phase: string): string {
+  return phase
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/scripts/file_utils.ts
+++ b/scripts/file_utils.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function writeFileAtomic(filePath: string, contents: string): Promise<boolean> {
+  const existing = await readFileIfExists(filePath);
+  if (existing === contents) {
+    return false;
+  }
+
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tempPath = path.join(dir, `.${base}.${process.pid}.${Date.now()}.tmp`);
+
+  try {
+    await fs.writeFile(tempPath, contents, 'utf8');
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await cleanupTempFile(tempPath);
+    throw error;
+  }
+
+  return true;
+}
+
+async function readFileIfExists(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function cleanupTempFile(tempPath: string): Promise<void> {
+  try {
+    await fs.unlink(tempPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}

--- a/scripts/generate_docs.ts
+++ b/scripts/generate_docs.ts
@@ -1,0 +1,315 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { PromptCatalog, PromptCatalogEntry, normalizePhaseLabel } from './catalog_types';
+import { writeFileAtomic } from './file_utils';
+
+interface GenerateDocsOptions {
+  updateWorkflow: boolean;
+}
+
+interface CrossEntry {
+  command: string;
+  stageTieIn: string;
+  purpose: string;
+}
+
+export async function generateDocs(
+  repoRoot: string,
+  catalog: PromptCatalog,
+  options: GenerateDocsOptions,
+): Promise<void> {
+  const readmeUpdated = await updateReadme(repoRoot, catalog);
+  if (readmeUpdated) {
+    console.log('Updated README.md metadata tables.');
+  } else {
+    console.log('README.md metadata tables already match catalog.json.');
+  }
+
+  if (options.updateWorkflow) {
+    const workflowUpdated = await regenerateWorkflow(repoRoot, catalog);
+    if (workflowUpdated) {
+      console.log('Regenerated workflow.mmd from catalog graph.');
+    } else {
+      console.log('workflow.mmd already up to date with catalog graph.');
+    }
+  } else {
+    console.log('Skipped workflow.mmd regeneration (pass --update-workflow to enable).');
+  }
+}
+
+async function updateReadme(repoRoot: string, catalog: PromptCatalog): Promise<boolean> {
+  const readmePath = path.join(repoRoot, 'README.md');
+  const original = await fs.readFile(readmePath, 'utf8');
+  const lines = original.split(/\r?\n/);
+  const usedPhases = new Set<string>();
+  let modified = false;
+  let crossHeadingIndex: number | null = null;
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line.startsWith('### [')) {
+      continue;
+    }
+    const headingLabel = extractHeadingLabel(line);
+    if (!headingLabel) {
+      continue;
+    }
+    if (headingLabel === 'Reset Playbook') {
+      crossHeadingIndex = index;
+      continue;
+    }
+    if (!/^P\d+/i.test(headingLabel)) {
+      continue;
+    }
+    const normalized = normalizePhaseLabel(headingLabel);
+    usedPhases.add(normalized);
+    const entries = catalog[normalized];
+    if (!entries) {
+      throw new Error(`README.md references phase "${headingLabel}" but catalog.json has no entries.`);
+    }
+    const bounds = locateTableBounds(lines, index + 1);
+    const tableLines = buildPhaseTable(entries);
+    if (!tableEquals(lines.slice(bounds.start, bounds.end), tableLines)) {
+      lines.splice(bounds.start, bounds.end - bounds.start, ...tableLines);
+      modified = true;
+    }
+  }
+
+  if (crossHeadingIndex !== null) {
+    const bounds = locateTableBounds(lines, crossHeadingIndex + 1);
+    const crossEntries = collectCrossEntries(catalog, usedPhases);
+    const tableLines = buildCrossTable(crossEntries);
+    if (!tableEquals(lines.slice(bounds.start, bounds.end), tableLines)) {
+      lines.splice(bounds.start, bounds.end - bounds.start, ...tableLines);
+      modified = true;
+    }
+  }
+
+  if (!modified) {
+    return false;
+  }
+
+  const updatedContent = ensureTrailingNewline(lines.join('\n'));
+  await writeFileAtomic(readmePath, updatedContent);
+  return true;
+}
+
+function extractHeadingLabel(line: string): string | null {
+  const bracketStart = line.indexOf('[');
+  const bracketEnd = line.indexOf('](', bracketStart);
+  if (bracketStart === -1 || bracketEnd === -1) {
+    return null;
+  }
+  return line.slice(bracketStart + 1, bracketEnd);
+}
+
+function locateTableBounds(lines: string[], startIndex: number): { start: number; end: number } {
+  let start = startIndex;
+  while (start < lines.length && lines[start].trim() === '') {
+    start++;
+  }
+  let end = start;
+  while (end < lines.length && lines[end].trim().startsWith('|')) {
+    end++;
+  }
+  return { start, end };
+}
+
+function buildPhaseTable(entries: PromptCatalogEntry[]): string[] {
+  const rows = entries
+    .slice()
+    .sort((a, b) => a.command.localeCompare(b.command))
+    .map((entry) => `| ${escapeCell(entry.command)} | ${escapeCell(entry.purpose)} |`);
+  return ['| Command | What it does |', '| --- | --- |', ...rows];
+}
+
+function collectCrossEntries(
+  catalog: PromptCatalog,
+  usedPhases: Set<string>,
+): CrossEntry[] {
+  const entries: CrossEntry[] = [];
+  const seen = new Set<string>();
+  for (const [normalized, bucket] of Object.entries(catalog)) {
+    if (usedPhases.has(normalized)) {
+      continue;
+    }
+    for (const entry of bucket) {
+      const key = `${entry.command}::${entry.phase}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      entries.push({
+        command: entry.command,
+        stageTieIn: entry.phase,
+        purpose: entry.purpose,
+      });
+    }
+  }
+  entries.sort((a, b) => {
+    const stage = a.stageTieIn.localeCompare(b.stageTieIn);
+    if (stage !== 0) {
+      return stage;
+    }
+    return a.command.localeCompare(b.command);
+  });
+  return entries;
+}
+
+function buildCrossTable(entries: CrossEntry[]): string[] {
+  const rows = entries.map(
+    (entry) => `| ${escapeCell(entry.command)} | ${escapeCell(entry.stageTieIn)} | ${escapeCell(entry.purpose)} |`,
+  );
+  return ['| Command | Stage tie-in | What it does |', '| --- | --- | --- |', ...rows];
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
+
+function tableEquals(existing: string[], replacement: string[]): boolean {
+  if (existing.length !== replacement.length) {
+    return false;
+  }
+  for (let index = 0; index < existing.length; index++) {
+    if (existing[index] !== replacement[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith('\n') ? content : `${content}\n`;
+}
+
+async function regenerateWorkflow(repoRoot: string, catalog: PromptCatalog): Promise<boolean> {
+  const workflowPath = path.join(repoRoot, 'workflow.mmd');
+  const lines = buildWorkflowGraph(catalog);
+  const payload = ensureTrailingNewline(lines.join('\n'));
+  return writeFileAtomic(workflowPath, payload);
+}
+
+function buildWorkflowGraph(catalog: PromptCatalog): string[] {
+  const phaseKeys = Object.keys(catalog);
+  const numbered = phaseKeys
+    .filter((key) => /^p\d/.test(key))
+    .sort((a, b) => comparePhaseKeys(a, b));
+  const nonNumbered = phaseKeys.filter((key) => !/^p\d/.test(key)).sort();
+  const orderedKeys = [...numbered, ...nonNumbered];
+
+  const commandAssignments = new Map<string, string>();
+  const commandLookup = new Map<string, PromptCatalogEntry>();
+  const phaseLabels = new Map<string, string>();
+
+  for (const key of orderedKeys) {
+    const bucket = catalog[key] ?? [];
+    if (bucket.length > 0) {
+      phaseLabels.set(key, bucket[0].phase);
+    }
+    for (const entry of bucket) {
+      if (!commandLookup.has(entry.command)) {
+        commandLookup.set(entry.command, entry);
+        commandAssignments.set(entry.command, key);
+      }
+    }
+  }
+
+  const lines: string[] = ['flowchart TD'];
+  for (const key of numbered) {
+    lines.push(...renderPhaseSubgraph(key, phaseLabels.get(key) ?? key, commandAssignments));
+  }
+
+  const crossPhaseNodes: string[] = [];
+  for (const key of nonNumbered) {
+    crossPhaseNodes.push(...renderPhaseSubgraph(key, phaseLabels.get(key) ?? key, commandAssignments));
+  }
+  if (crossPhaseNodes.length > 0) {
+    lines.push(...crossPhaseNodes);
+  }
+
+  const edges = buildEdges(commandLookup);
+  lines.push(...edges);
+  return lines;
+}
+
+function renderPhaseSubgraph(
+  phaseKey: string,
+  label: string,
+  commandAssignments: Map<string, string>,
+): string[] {
+  const commands: string[] = [];
+  for (const [command, assignedPhase] of commandAssignments.entries()) {
+    if (assignedPhase !== phaseKey) {
+      continue;
+    }
+    commands.push(command);
+  }
+  if (commands.length === 0) {
+    return [];
+  }
+  commands.sort((a, b) => a.localeCompare(b));
+  const lines: string[] = [];
+  const phaseId = toPhaseId(phaseKey);
+  lines.push(`  subgraph ${phaseId}["${escapeLabel(label)}"]`);
+  for (const command of commands) {
+    const nodeId = toCommandId(command);
+    lines.push(`    ${nodeId}[/${command}/]`);
+  }
+  lines.push('  end');
+  return lines;
+}
+
+function buildEdges(commandLookup: Map<string, PromptCatalogEntry>): string[] {
+  const edges: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of commandLookup.values()) {
+    const sourceId = toCommandId(entry.command);
+    for (const nextCommand of entry.next) {
+      const targetEntry = commandLookup.get(nextCommand);
+      if (!targetEntry) {
+        continue;
+      }
+      const targetId = toCommandId(targetEntry.command);
+      const key = `${sourceId}->${targetId}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      edges.push(`  ${sourceId} --> ${targetId}`);
+    }
+  }
+  return edges.sort((a, b) => a.localeCompare(b));
+}
+
+function toPhaseId(phaseKey: string): string {
+  return `phase_${phaseKey.replace(/[^a-z0-9]/g, '_')}`;
+}
+
+function toCommandId(command: string): string {
+  const stripped = command.replace(/^\//, '');
+  const normalized = stripped.replace(/[^a-z0-9]/gi, '_');
+  return `cmd_${normalized}`;
+}
+
+function escapeLabel(label: string): string {
+  return label.replace(/"/g, '\\"');
+}
+
+function comparePhaseKeys(a: string, b: string): number {
+  const numberA = extractPhaseNumber(a);
+  const numberB = extractPhaseNumber(b);
+  if (numberA !== null && numberB !== null && numberA !== numberB) {
+    return numberA - numberB;
+  }
+  return a.localeCompare(b);
+}
+
+function extractPhaseNumber(key: string): number | null {
+  const match = key.match(/^p(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return Number.parseInt(match[1], 10);
+}


### PR DESCRIPTION
## Summary
- add shared catalog types, atomic file writer, and documentation generator utilities
- update the catalog build script to refresh README tables and support optional workflow regeneration
- refresh README tables to reflect the latest prompt metadata

## Testing
- npm run build:catalog
- npm run validate:metadata

------
https://chatgpt.com/codex/tasks/task_e_68cdc53b95708328b92db2416bed1e83