### PR TITLE
Automate WORKFLOW.md synchronization with catalog phases

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -32,6 +32,7 @@ M5 Production release with rollback tested.
 
 ## 5) Phases
 
+<!-- BEGIN GENERATED PHASES -->
 ### P0 Preflight Docs (Blocking)
 
 - **Purpose**: Enforce docs-first policy and record DocFetchReport.&#x20;
@@ -42,6 +43,10 @@ M5 Production release with rollback tested.
 - **Risks**: Missing docs.
 - **Owners**: Planner.
 
+<!-- commands:start -->
+- _No catalog commands mapped to this phase._
+<!-- commands:end -->
+
 ### P1 Plan & Scope
 
 - **Purpose**: Lock scope and acceptance.
@@ -49,6 +54,13 @@ M5 Production release with rollback tested.
 - **Gate**: Scope Gate passed.
 - **Outputs**: PLAN.md, scope table.
 - **Owners**: Planner.
+
+<!-- commands:start -->
+- `/planning-process` — Draft, refine, and execute a feature plan with strict scope control and progress tracking.
+- `/prototype-feature` — Spin up a standalone prototype in a clean repo before merging into main.
+- `/scope-control` — Enforce explicit scope boundaries and maintain "won't do" and "ideas for later" lists.
+- `/stack-evaluation` — Evaluate language/framework choices relative to AI familiarity and repo goals.
+<!-- commands:end -->
 
 ### P2 App Scaffold & Contracts
 
@@ -62,6 +74,15 @@ M5 Production release with rollback tested.
 - **Outputs**: repo tree, OpenAPI/SDL.
 - **Owners**: Full-stack dev.
 
+<!-- commands:start -->
+- `/api-contract "<feature or domain>"` — Author an initial OpenAPI 3.1 or GraphQL SDL contract from requirements.
+- `/api-docs-local` — Fetch API docs and store locally for offline, deterministic reference.
+- `/openapi-generate <server|client> <lang> <spec-path>` — Generate server stubs or typed clients from an OpenAPI spec.
+- `/prototype-feature` — Spin up a standalone prototype in a clean repo before merging into main.
+- `/reference-implementation` — Mimic the style and API of a known working example.
+- `/scaffold-fullstack <stack>` — Create a minimal, production-ready monorepo template with app, API, tests, CI seeds, and infra stubs.
+<!-- commands:end -->
+
 ### P3 Data & Auth
 
 - **Purpose**: Persistence and identity.
@@ -72,6 +93,12 @@ M5 Production release with rollback tested.
 - **Outputs**: migrations, seed script, auth routes.
 - **Owners**: API dev, Security.
 
+<!-- commands:start -->
+- `/auth-scaffold <oauth|email|oidc>` — Scaffold auth flows, routes, storage, and a basic threat model.
+- `/db-bootstrap <postgres|mysql|sqlite|mongodb>` — Pick a database, initialize migrations, local compose, and seed scripts.
+- `/migration-plan "<change summary>"` — Produce safe up/down migration steps with checks and rollback notes.
+<!-- commands:end -->
+
 ### P4 Frontend UX
 
 - **Purpose**: Routes and components.
@@ -79,6 +106,11 @@ M5 Production release with rollback tested.
 - **Gate**: Accessibility checks queued.
 - **Outputs**: Screens, states, assets.
 - **Owners**: Frontend.
+
+<!-- commands:start -->
+- `/design-assets` — Generate favicons and small design snippets from product brand.
+- `/ui-screenshots` — Analyze screenshots for UI bugs or inspiration and propose actionable UI changes.
+<!-- commands:end -->
 
 ### P5 Quality Gates & Tests
 
@@ -89,6 +121,14 @@ M5 Production release with rollback tested.
 - **Outputs**: E2E suite, coverage plan.
 - **Owners**: QA.
 
+<!-- commands:start -->
+- `/coverage-guide` — Propose high-ROI tests to raise coverage using uncovered areas.
+- `/e2e-runner-setup <playwright|cypress>` — Configure an end-to-end test runner with fixtures and a data sandbox.
+- `/generate <source-file>` — Generate unit tests for a given source file.
+- `/integration-test` — Generate E2E tests that simulate real user flows.
+- `/regression-guard` — Detect unrelated changes and add tests to prevent regressions.
+<!-- commands:end -->
+
 ### P6 CI/CD & Env
 
 - **Purpose**: Reproducible pipeline and environments.
@@ -96,6 +136,15 @@ M5 Production release with rollback tested.
 - **Gate**: Review Gate = CI green, approvals, no unrelated churn.
 - **Outputs**: CI config, IaC, secret store wiring.
 - **Owners**: DevOps.
+
+<!-- commands:start -->
+- `/devops-automation` — Configure servers, DNS, SSL, CI/CD at a pragmatic level.
+- `/env-setup` — Create .env.example, runtime schema validation, and per-env overrides.
+- `/iac-bootstrap <aws|gcp|azure|fly|render>` — Create minimal Infrastructure-as-Code for the chosen platform plus CI hooks.
+- `/secrets-manager-setup <provider>` — Provision a secrets store and map application variables to it.
+- `/version-control-guide` — Enforce clean incremental commits and clean-room re-implementation when finalizing.
+- `commit` — Generate a conventional, review-ready commit message from the currently staged changes.
+<!-- commands:end -->
 
 ### P7 Release & Ops
 
@@ -105,6 +154,19 @@ M5 Production release with rollback tested.
 - **Outputs**: Release notes, dashboards, runbooks.
 - **Owners**: Dev, DevOps, SRE.
 
+<!-- commands:start -->
+- `/audit` — Audit repository hygiene and suggest improvements.
+- `/explain-code` — Provide line-by-line explanations for a given file or diff.
+- `/monitoring-setup` — Bootstrap logs, metrics, and traces with dashboards per domain.
+- `/owners <path>` — Suggest likely owners or reviewers for the specified path.
+- `/pr-desc <context>` — Draft a PR description from the branch diff.
+- `/release-notes <git-range>` — Generate human-readable release notes from recent commits.
+- `/review <pattern>` — Review code matching a pattern and deliver actionable feedback.
+- `/review-branch` — Provide a high-level review of the current branch versus origin/main.
+- `/slo-setup` — Define Service Level Objectives, burn alerts, and runbooks.
+- `/version-proposal` — Propose the next semantic version based on commit history.
+<!-- commands:end -->
+
 ### P8 Post-release Hardening
 
 - **Purpose**: Stability and cleanup.
@@ -113,6 +175,16 @@ M5 Production release with rollback tested.
 - **Outputs**: Clean diff, flags in place.
 - **Owners**: Dev.
 
+<!-- commands:start -->
+- `/cleanup-branches` — Recommend which local branches are safe to delete and which to keep.
+- `/dead-code-scan` — Identify likely dead or unused files and exports using static signals.
+- `/error-analysis` — Analyze error logs and enumerate likely root causes with fixes.
+- `/feature-flags <provider>` — Integrate a flag provider, wire the SDK, and enforce guardrails.
+- `/file-modularity` — Enforce smaller files and propose safe splits for giant files.
+- `/fix "<bug summary>"` — Propose a minimal, correct fix with diff-style patches.
+- `/refactor-suggestions` — Propose repo-wide refactoring opportunities after tests exist.
+<!-- commands:end -->
+
 ### P9 Model Tactics (cross-cutting)
 
 - **Purpose**: Optimize prompting/model choice.
@@ -120,6 +192,73 @@ M5 Production release with rollback tested.
 - **Gate**: Model delta improves QoS.
 - **Owners**: Planner.
 
+<!-- commands:start -->
+- _No catalog commands mapped to this phase._
+<!-- commands:end -->
+
+### 11) Evidence Log
+
+- **Purpose**: _Document the goal for 11) Evidence Log._
+- **Steps**: _Outline the prompts and activities involved._
+- **Gate Criteria**: _Capture the exit checks before advancing._
+- **Outputs**: _List the deliverables for this phase._
+- **Owners**: _Assign accountable roles._
+
+<!-- commands:start -->
+- `/content-generation` — Draft docs, blog posts, or marketing copy aligned with the codebase.
+<!-- commands:end -->
+
+### P0 Preflight Docs
+
+- **Purpose**: _Document the goal for P0 Preflight Docs._
+- **Steps**: _Outline the prompts and activities involved._
+- **Gate Criteria**: _Capture the exit checks before advancing._
+- **Outputs**: _List the deliverables for this phase._
+- **Owners**: _Assign accountable roles._
+
+<!-- commands:start -->
+- `/instruction-file` — Generate or update `cursor.rules`, `windsurf.rules`, or `claude.md` with project-specific instructions.
+<!-- commands:end -->
+
+### P9 Model Tactics
+
+- **Purpose**: _Document the goal for P9 Model Tactics._
+- **Steps**: _Outline the prompts and activities involved._
+- **Gate Criteria**: _Capture the exit checks before advancing._
+- **Outputs**: _List the deliverables for this phase._
+- **Owners**: _Assign accountable roles._
+
+<!-- commands:start -->
+- `/compare-outputs` — Run multiple models or tools on the same prompt and summarize best output.
+- `/model-evaluation` — Try a new model and compare outputs against a baseline.
+- `/model-strengths` — Choose model per task type.
+- `/switch-model` — Decide when to try a different AI backend and how to compare.
+<!-- commands:end -->
+
+### Reset Playbook
+
+- **Purpose**: _Document the goal for Reset Playbook._
+- **Steps**: _Outline the prompts and activities involved._
+- **Gate Criteria**: _Capture the exit checks before advancing._
+- **Outputs**: _List the deliverables for this phase._
+- **Owners**: _Assign accountable roles._
+
+<!-- commands:start -->
+- `/reset-strategy` — Decide when to hard reset and start clean to avoid layered bad diffs.
+<!-- commands:end -->
+
+### Support
+
+- **Purpose**: _Document the goal for Support._
+- **Steps**: _Outline the prompts and activities involved._
+- **Gate Criteria**: _Capture the exit checks before advancing._
+- **Outputs**: _List the deliverables for this phase._
+- **Owners**: _Assign accountable roles._
+
+<!-- commands:start -->
+- `/voice-input` — Support interaction from voice capture and convert to structured prompts.
+<!-- commands:end -->
+<!-- END GENERATED PHASES -->
 ## 6) Dev Loop Rules
 
 Commit small. One concern per PR. Use clean-room finalize if diff grows. Reset when E2E red for >60m or design drift detected. Enforce branch policy via `/version-control-guide`.&#x20;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "validate:metadata": "ts-node scripts/validate_metadata.ts",
-    "build:catalog": "ts-node scripts/build_catalog.ts"
+    "build:catalog": "ts-node scripts/build_catalog.ts",
+    "test": "ts-node scripts/__tests__/workflow_sync.test.ts"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/scripts/__tests__/workflow_sync.test.ts
+++ b/scripts/__tests__/workflow_sync.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { PromptCatalog } from '../catalog_types';
+import { regenerateWorkflow, synchronizeWorkflowDoc } from '../generate_docs';
+
+async function main(): Promise<void> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'workflow-sync-'));
+  const repoRoot = path.join(tmpRoot, 'repo');
+  await fs.mkdir(repoRoot, { recursive: true });
+
+  const workflowPath = path.join(repoRoot, 'WORKFLOW.md');
+  const workflowGraphPath = path.join(repoRoot, 'workflow.mmd');
+
+  const initialWorkflow = `# Workflow\n\n## 5) Phases\n\n${'<!-- BEGIN GENERATED PHASES -->'}\n### P0 Preflight Docs (Blocking)\n\n- **Purpose**: Placeholder.\n${'<!-- commands:start -->'}\n- _No catalog commands mapped to this phase._\n${'<!-- commands:end -->'}\n${'<!-- END GENERATED PHASES -->'}\n`;
+  await fs.writeFile(workflowPath, initialWorkflow, 'utf8');
+  await fs.writeFile(workflowGraphPath, 'flowchart TD\n', 'utf8');
+
+  const catalogBefore: PromptCatalog = {
+    'p0-preflight-docs-blocking': [
+      {
+        phase: 'P0 Preflight Docs (Blocking)',
+        command: '/alpha',
+        title: 'Alpha',
+        purpose: 'Initial command.',
+        gate: 'Gate',
+        status: 'Stable',
+        previous: [],
+        next: [],
+        path: 'prompts/alpha.md',
+      },
+    ],
+  };
+
+  await synchronizeWorkflowDoc(repoRoot, catalogBefore);
+  await regenerateWorkflow(repoRoot, catalogBefore);
+
+  let workflow = await fs.readFile(workflowPath, 'utf8');
+  assert.ok(workflow.includes('`/alpha`'), 'expected initial command in workflow doc');
+  let mermaid = await fs.readFile(workflowGraphPath, 'utf8');
+  assert.ok(mermaid.includes('/alpha/'), 'expected initial command in workflow graph');
+
+  const catalogAfter: PromptCatalog = {
+    'p0-preflight-docs-blocking': [
+      {
+        phase: 'P0 Preflight Docs (Blocking)',
+        command: '/beta',
+        title: 'Beta',
+        purpose: 'Renamed command.',
+        gate: 'Gate',
+        status: 'Stable',
+        previous: [],
+        next: [],
+        path: 'prompts/alpha.md',
+      },
+    ],
+  };
+
+  await synchronizeWorkflowDoc(repoRoot, catalogAfter);
+  await regenerateWorkflow(repoRoot, catalogAfter);
+
+  workflow = await fs.readFile(workflowPath, 'utf8');
+  assert.ok(workflow.includes('`/beta`'), 'expected renamed command in workflow doc');
+  assert.ok(!workflow.includes('`/alpha`'), 'expected original command removed from workflow doc');
+
+  mermaid = await fs.readFile(workflowGraphPath, 'utf8');
+  assert.ok(mermaid.includes('/beta/'), 'expected renamed command in workflow graph');
+  assert.ok(!mermaid.includes('/alpha/'), 'expected original command removed from workflow graph');
+
+  console.log('workflow sync regression test passed.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/workflow.mmd
+++ b/workflow.mmd
@@ -1,107 +1,125 @@
 flowchart TD
-  subgraph P0["P0 Preflight Docs"]
-    preflight["Preflight Docs (§A) AGENTS"]
+  subgraph phase_p0_preflight_docs["P0 Preflight Docs"]
+    cmd_instruction_file[//instruction-file/]
   end
-
-  subgraph P1["P1 Plan & Scope"]
-    plan[/planning-process/]
-    scope[/scope-control/]
-    stack[/stack-evaluation/]
+  subgraph phase_p1_plan_scope["P1 Plan & Scope"]
+    cmd_planning_process[//planning-process/]
+    cmd_prototype_feature[//prototype-feature/]
+    cmd_scope_control[//scope-control/]
+    cmd_stack_evaluation[//stack-evaluation/]
   end
-
-  subgraph P2["P2 App Scaffold & Contracts"]
-    scaffold[/scaffold-fullstack/]
-    api_contract[/api-contract/]
-    openapi[/openapi-generate/]
-    modular[/modular-architecture/]
+  subgraph phase_p2_app_scaffold_contracts["P2 App Scaffold & Contracts"]
+    cmd_api_contract___feature_or_domain__[//api-contract "<feature or domain>"/]
+    cmd_api_docs_local[//api-docs-local/]
+    cmd_openapi_generate__server_client___lang___spec_path_[//openapi-generate <server|client> <lang> <spec-path>/]
+    cmd_reference_implementation[//reference-implementation/]
+    cmd_scaffold_fullstack__stack_[//scaffold-fullstack <stack>/]
   end
-
-  subgraph P3["P3 Data & Auth"]
-    db[/db-bootstrap/]
-    migrate[/migration-plan/]
-    auth[/auth-scaffold/]
+  subgraph phase_p3_data_auth["P3 Data & Auth"]
+    cmd_auth_scaffold__oauth_email_oidc_[//auth-scaffold <oauth|email|oidc>/]
+    cmd_db_bootstrap__postgres_mysql_sqlite_mongodb_[//db-bootstrap <postgres|mysql|sqlite|mongodb>/]
+    cmd_migration_plan___change_summary__[//migration-plan "<change summary>"/]
   end
-
-  subgraph P4["P4 Frontend UX"]
-    assets[/design-assets/]
-    screenshots[/ui-screenshots/]
+  subgraph phase_p4_frontend_ux["P4 Frontend UX"]
+    cmd_design_assets[//design-assets/]
+    cmd_ui_screenshots[//ui-screenshots/]
   end
-
-  subgraph P5["P5 Quality Gates & Tests"]
-    e2e[/e2e-runner-setup/]
-    integration[/integration-test/]
-    coverage[/coverage-guide/]
-    regression[/regression-guard/]
+  subgraph phase_p5_quality_gates_tests["P5 Quality Gates & Tests"]
+    cmd_coverage_guide[//coverage-guide/]
+    cmd_e2e_runner_setup__playwright_cypress_[//e2e-runner-setup <playwright|cypress>/]
+    cmd_generate__source_file_[//generate <source-file>/]
+    cmd_integration_test[//integration-test/]
+    cmd_regression_guard[//regression-guard/]
   end
-
-  subgraph P6["P6 CI/CD & Env"]
-    vcs[/version-control-guide/]
-    devops[/devops-automation/]
-    env[/env-setup/]
-    secrets[/secrets-manager-setup/]
-    iac[/iac-bootstrap/]
+  subgraph phase_p6_ci_cd_env["P6 CI/CD & Env"]
+    cmd_devops_automation[//devops-automation/]
+    cmd_env_setup[//env-setup/]
+    cmd_iac_bootstrap__aws_gcp_azure_fly_render_[//iac-bootstrap <aws|gcp|azure|fly|render>/]
+    cmd_secrets_manager_setup__provider_[//secrets-manager-setup <provider>/]
+    cmd_version_control_guide[//version-control-guide/]
+    cmd_commit[/commit/]
   end
-
-  subgraph P7["P7 Release & Ops"]
-    owners[/owners/]
-    review[/review/]
-    review_branch[/review-branch/]
-    pr_desc[/pr-desc/]
-    release_notes[/release-notes/]
-    version[/version-proposal/]
-    monitoring[/monitoring-setup/]
-    slo[/slo-setup/]
-    logging[/logging-strategy/]
-    audit[/audit/]
+  subgraph phase_p7_release_ops["P7 Release & Ops"]
+    cmd_audit[//audit/]
+    cmd_explain_code[//explain-code/]
+    cmd_monitoring_setup[//monitoring-setup/]
+    cmd_owners__path_[//owners <path>/]
+    cmd_pr_desc__context_[//pr-desc <context>/]
+    cmd_release_notes__git_range_[//release-notes <git-range>/]
+    cmd_review__pattern_[//review <pattern>/]
+    cmd_review_branch[//review-branch/]
+    cmd_slo_setup[//slo-setup/]
+    cmd_version_proposal[//version-proposal/]
   end
-
-  subgraph Deploy["Deployment Flow"]
-    deploy_staging[Deploy Staging]
-    canary[Canary + Health]
-    deploy_prod[Deploy Prod]
-    rollback[Rollback]
+  subgraph phase_p8_post_release_hardening["P8 Post-release Hardening"]
+    cmd_cleanup_branches[//cleanup-branches/]
+    cmd_dead_code_scan[//dead-code-scan/]
+    cmd_error_analysis[//error-analysis/]
+    cmd_feature_flags__provider_[//feature-flags <provider>/]
+    cmd_file_modularity[//file-modularity/]
+    cmd_fix___bug_summary__[//fix "<bug summary>"/]
+    cmd_refactor_suggestions[//refactor-suggestions/]
   end
-
-  subgraph P8["P8 Post-release Hardening"]
-    error[/error-analysis/]
-    fix[/fix/]
-    refactor[/refactor-suggestions/]
-    modularity[/file-modularity/]
-    deadcode[/dead-code-scan/]
-    cleanup[/cleanup-branches/]
-    flags[/feature-flags/]
+  subgraph phase_p9_model_tactics["P9 Model Tactics"]
+    cmd_compare_outputs[//compare-outputs/]
+    cmd_model_evaluation[//model-evaluation/]
+    cmd_model_strengths[//model-strengths/]
+    cmd_switch_model[//switch-model/]
   end
-
-  subgraph P9["P9 Model Tactics"]
-    strengths[/model-strengths/]
-    evaluation[/model-evaluation/]
-    compare[/compare-outputs/]
-    switch[/switch-model/]
+  subgraph phase_11_evidence_log["11) Evidence Log"]
+    cmd_content_generation[//content-generation/]
   end
-
-  scope_gate{Scope Gate}
-  test_gate_lite{Test Gate lite}
-  ux_gate{Accessibility checks queued}
-  test_gate{Test Gate}
-  review_gate{Review Gate}
-  release_gate{Release Gate}
-  hardening_gate{Sev-1 resolved}
-
-  preflight --> plan
-  plan --> scope --> stack --> scope_gate
-  scope_gate --> scaffold
-  scaffold --> api_contract --> openapi --> modular --> test_gate_lite
-  test_gate_lite --> db
-  db --> migrate --> auth --> assets --> screenshots --> ux_gate
-  ux_gate --> e2e --> integration --> coverage --> regression --> test_gate
-  test_gate --> vcs --> devops --> env --> secrets --> iac --> review_gate
-  review_gate --> owners --> review --> review_branch --> pr_desc --> release_notes --> version --> release_gate
-  release_gate --> deploy_staging --> canary --> deploy_prod
-  canary --> rollback
-  deploy_prod --> monitoring --> slo --> logging --> audit --> hardening_gate
-  deploy_prod --> error
-  error --> fix --> refactor --> modularity --> deadcode --> cleanup --> flags --> hardening_gate
-  deploy_prod --> flags
-  deploy_prod --> strengths
-  strengths --> evaluation --> compare --> switch
-  flags --> strengths
+  subgraph phase_reset_playbook["Reset Playbook"]
+    cmd_reset_strategy[//reset-strategy/]
+  end
+  subgraph phase_support["Support"]
+    cmd_voice_input[//voice-input/]
+  end
+  cmd_audit --> cmd_error_analysis
+  cmd_auth_scaffold__oauth_email_oidc_ --> cmd_ui_screenshots
+  cmd_cleanup_branches --> cmd_model_strengths
+  cmd_commit --> cmd_devops_automation
+  cmd_commit --> cmd_env_setup
+  cmd_compare_outputs --> cmd_switch_model
+  cmd_coverage_guide --> cmd_regression_guard
+  cmd_coverage_guide --> cmd_version_control_guide
+  cmd_dead_code_scan --> cmd_cleanup_branches
+  cmd_design_assets --> cmd_ui_screenshots
+  cmd_devops_automation --> cmd_env_setup
+  cmd_e2e_runner_setup__playwright_cypress_ --> cmd_coverage_guide
+  cmd_e2e_runner_setup__playwright_cypress_ --> cmd_integration_test
+  cmd_error_analysis --> cmd_refactor_suggestions
+  cmd_explain_code --> cmd_review_branch
+  cmd_feature_flags__provider_ --> cmd_model_evaluation
+  cmd_feature_flags__provider_ --> cmd_model_strengths
+  cmd_file_modularity --> cmd_cleanup_branches
+  cmd_file_modularity --> cmd_dead_code_scan
+  cmd_fix___bug_summary__ --> cmd_file_modularity
+  cmd_fix___bug_summary__ --> cmd_refactor_suggestions
+  cmd_generate__source_file_ --> cmd_regression_guard
+  cmd_instruction_file --> cmd_planning_process
+  cmd_instruction_file --> cmd_scope_control
+  cmd_integration_test --> cmd_coverage_guide
+  cmd_integration_test --> cmd_regression_guard
+  cmd_model_evaluation --> cmd_compare_outputs
+  cmd_model_evaluation --> cmd_switch_model
+  cmd_model_strengths --> cmd_compare_outputs
+  cmd_model_strengths --> cmd_model_evaluation
+  cmd_monitoring_setup --> cmd_slo_setup
+  cmd_owners__path_ --> cmd_review_branch
+  cmd_planning_process --> cmd_scope_control
+  cmd_planning_process --> cmd_stack_evaluation
+  cmd_pr_desc__context_ --> cmd_version_proposal
+  cmd_refactor_suggestions --> cmd_dead_code_scan
+  cmd_refactor_suggestions --> cmd_file_modularity
+  cmd_regression_guard --> cmd_devops_automation
+  cmd_regression_guard --> cmd_version_control_guide
+  cmd_release_notes__git_range_ --> cmd_monitoring_setup
+  cmd_release_notes__git_range_ --> cmd_version_proposal
+  cmd_review__pattern_ --> cmd_review_branch
+  cmd_scope_control --> cmd_stack_evaluation
+  cmd_slo_setup --> cmd_audit
+  cmd_version_control_guide --> cmd_devops_automation
+  cmd_version_control_guide --> cmd_env_setup
+  cmd_version_proposal --> cmd_monitoring_setup
+  cmd_version_proposal --> cmd_slo_setup


### PR DESCRIPTION
## Summary
- update the catalog builder to track unknown phases, sync WORKFLOW.md when --update-workflow is used, and reload the phase index
- add a synchronizeWorkflowDoc helper that rewrites the generated phase block, stubs new phases, and keeps workflow.mmd in step with the catalog
- restructure WORKFLOW.md around generated markers and add a regression test that renaming a command updates both WORKFLOW.md and workflow.mmd

## Testing
- npm run test
- npm run validate:metadata
- npm run build:catalog -- --update-workflow

------
https://chatgpt.com/codex/tasks/task_e_68cddd0ecf348328845492a8d1a32e1e